### PR TITLE
Fixed exception that thrown when api key is real but was deleted from…

### DIFF
--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_connection.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_connection.py
@@ -71,7 +71,10 @@ class BinanceWebSocketApiConnection(object):
             self.handler_binance_websocket_api_manager.set_restart_request(self.stream_id)
             sys.exit(1)
         try:
-            if uri['code'] == -2014 or uri['code'] == -2015:
+            if uri['code'] == -2014 or uri['code'] == -2015 or uri['code'] == -2008:
+                # -2014 = API-key format invalid
+                # -2015 = Invalid API-key, IP, or permissions for action
+                # -2008 = Invalid Api-Key ID
                 # cant get a valid listen_key, so this stream has to crash
                 logging.critical("BinanceWebSocketApiConnection->await._conn.__aenter__(" + str(self.stream_id) + ", " +
                                  str(self.channels) + ", " + str(self.markets) + ") - " + str(uri['msg']))


### PR DESCRIPTION
## Description

When api key is real but was deleted from binance account then api returns dict with code -2008 and message "Invalid Api-Key ID".
To prevent library throw AttributeError on parsing uri, which is dict when this error occurs, i've added another filter to crush thread

## Related Issue

Sorry, i didn't create issue. You can check this bug fast before accepting or declining my pull request.

## Motivation and Context

It fixes unexpected behavior.

## How Has This Been Tested

It was tested on trading application.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the 
**[CONTRIBUTING](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/blob/master/CONTRIBUTING.md)** 
document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
