### PR TITLE
Adding Testnet endpoints for spot, margin, isolated_margin and futures!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [Semantic Versioning](http://semver.org/).
 
 ## 1.17.4.dev (development stage/unreleased/unstable)
+
+### Added
+- binance.com testnets
+
 ## 1.17.4
 ### Added
 - `replace_stream()`: new_stream_label=None, new_stream_buffer_name=False, new_symbol=False, new_api_key=False, 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@
 [Notifications](#receive-notifications) | [Bugs](#how-to-report-bugs-or-suggest-improvements) | 
 [Contributing](#contributing)
 
-An unofficial Python API to use the Binance Websocket API's (com, com-margin, com-isolated_margin, com-futures, jersey, us, jex, dex/chain+testnet) in a easy, fast, flexible, robust and fully-featured way.
-
+An unofficial Python API to use the Binance Websocket API`s (com+testnet, com-margin+testnet, com-isolated_margin+testnet, com-futures+testnet, jersey, us, jex, dex/chain+testnet) in a easy, fast, flexible, robust and fully-featured way. 
 ### [Create a multiplex websocket connection](https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/unicorn_binance_websocket_api.html#unicorn_binance_websocket_api.unicorn_binance_websocket_api_manager.BinanceWebSocketApiManager.create_stream) to Binance with just 3 lines of code:
 ```
 from unicorn_binance_websocket_api.unicorn_binance_websocket_api_manager import BinanceWebSocketApiManager
@@ -62,10 +61,15 @@ This should be known by everyone using this lib: [Do you want consistent data fr
 
 ## Description
 The Python module [UNICORN Binance WebSocket API](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api) 
-provides an API to the Binance Websocket API`s of [Binance](https://github.com/binance-exchange/binance-official-api-docs), 
-[Binance Margin](https://binance-docs.github.io/apidocs/spot/en/#user-data-streams),
-[Binance Isolated Margin](https://binance-docs.github.io/apidocs/spot/en/#listen-key-isolated-margin),
-[Binance Futures](https://binance-docs.github.io/apidocs/futures/en/#websocket-market-streams), 
+provides an API to the Binance Websocket API`s of 
+[Binance](https://github.com/binance-exchange/binance-official-api-docs) 
+([+Testnet](https://testnet.binance.vision/)), 
+[Binance Margin](https://binance-docs.github.io/apidocs/spot/en/#user-data-streams) 
+([+Testnet](https://testnet.binance.vision/)), 
+[Binance Isolated Margin](https://binance-docs.github.io/apidocs/spot/en/#listen-key-isolated-margin)
+([+Testnet](https://testnet.binance.vision/)), 
+[Binance Futures](https://binance-docs.github.io/apidocs/futures/en/#websocket-market-streams) 
+([+Testnet](https://testnet.binancefuture.com)), 
 [Binance Jersey](https://github.com/binance-jersey/binance-official-api-docs/), 
 [Binance US](https://github.com/binance-us/binance-official-api-docs), 
 [Binance JEX](https://jexapi.github.io/api-doc/spot.html#web-socket-streams), 
@@ -94,15 +98,32 @@ on, you have to use the Binance Rest API ([com](https://github.com/binance-excha
 ### What are the benefits of the UNICORN Binance WebSocket API?
 - Fully managed websockets and 100% auto-reconnect!
 - Supported exchanges: 
-    * [Binance](https://www.binance.com) `BinanceWebSocketApiManager(exchange="binance.com")`
-    * [Binance Margin](https://www.binance.com) `BinanceWebSocketApiManager(exchange="binance.com-margin")`
-    * [Binance Isolated Margin](https://www.binance.com) `BinanceWebSocketApiManager(exchange="binance.com-isolated_margin")`
-    * [Binance Futures](https://www.binance.com) `BinanceWebSocketApiManager(exchange="binance.com-futures")`
-    * [Binance Jersey](https://www.binance.je) `BinanceWebSocketApiManager(exchange="binance.je")`
-    * [Binance US](https://www.binance.us) `BinanceWebSocketApiManager(exchange="binance.us")`
-    * [Binance JEX](https://www.jex.com) `BinanceWebSocketApiManager(exchange="jex.com")`
-    * [Binance DEX](https://www.binance.org) `BinanceWebSocketApiManager(exchange="binance.org")`
-    * [Binance DEX testnet](https://testnet.binance.org) `BinanceWebSocketApiManager(exchange="binance.org-testnet")`
+    * [Binance](https://www.binance.com) 
+     `BinanceWebSocketApiManager(exchange="binance.com")`
+    * [Binance](https://testnet.binance.vision/)
+     `BinanceWebSocketApiManager(exchange="binance.com-testnet")`
+    * [Binance Margin](https://www.binance.com)
+     `BinanceWebSocketApiManager(exchange="binance.com-margin")`
+    * [Binance Margin Testnet](https://testnet.binance.vision/)
+     `BinanceWebSocketApiManager(exchange="binance.com-margin-testnet")`
+    * [Binance Isolated Margin](https://www.binance.com)
+     `BinanceWebSocketApiManager(exchange="binance.com-isolated_margin")`
+    * [Binance Isolated Margin Testnet](https://testnet.binance.vision/)
+     `BinanceWebSocketApiManager(exchange="binance.com-isolated_margin-testnet")`
+    * [Binance Futures](https://www.binance.com)
+     `BinanceWebSocketApiManager(exchange="binance.com-futures")`
+    * [Binance Futures Testnet](https://testnet.binancefuture.com)
+     `BinanceWebSocketApiManager(exchange="binance.com-futures-testnet")`
+    * [Binance Jersey](https://www.binance.je)
+     `BinanceWebSocketApiManager(exchange="binance.je")`
+    * [Binance US](https://www.binance.us)
+     `BinanceWebSocketApiManager(exchange="binance.us")`
+    * [Binance JEX](https://www.jex.com)
+     `BinanceWebSocketApiManager(exchange="jex.com")`
+    * [Binance DEX](https://www.binance.org)
+     `BinanceWebSocketApiManager(exchange="binance.org")`
+    * [Binance DEX testnet](https://testnet.binance.org)
+     `BinanceWebSocketApiManager(exchange="binance.org-testnet")`
 - Streams are processing asynchronous/concurrent (Python asyncio) and each stream is started in a separate thread, but 
 you dont need to deal with asyncio in your code!
 - No use of the twisted module, so you can use this lib in a daemonized application (compatible with 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ on, you have to use the Binance Rest API ([com](https://github.com/binance-excha
 - Supported exchanges: 
     * [Binance](https://www.binance.com) 
      `BinanceWebSocketApiManager(exchange="binance.com")`
-    * [Binance](https://testnet.binance.vision/)
+    * [Binance Testnet](https://testnet.binance.vision/)
      `BinanceWebSocketApiManager(exchange="binance.com-testnet")`
     * [Binance Margin](https://www.binance.com)
      `BinanceWebSocketApiManager(exchange="binance.com-margin")`
@@ -122,7 +122,7 @@ on, you have to use the Binance Rest API ([com](https://github.com/binance-excha
      `BinanceWebSocketApiManager(exchange="jex.com")`
     * [Binance DEX](https://www.binance.org)
      `BinanceWebSocketApiManager(exchange="binance.org")`
-    * [Binance DEX testnet](https://testnet.binance.org)
+    * [Binance DEX Testnet](https://testnet.binance.org)
      `BinanceWebSocketApiManager(exchange="binance.org-testnet")`
 - Streams are processing asynchronous/concurrent (Python asyncio) and each stream is started in a separate thread, but 
 you dont need to deal with asyncio in your code!

--- a/example_process_streams.py
+++ b/example_process_streams.py
@@ -58,13 +58,13 @@ class BinanceWebSocketApiProcessStreams(object):
         # to see the difference.
         # Github: https://github.com/oliver-zehentleitner/unicorn_fy
         # PyPI: https://pypi.org/project/unicorn-fy/
-        if exchange == "binance.com":
+        if exchange == "binance.com" or exchange == "binance.com-testnet":
             unicorn_fied_stream_data = UnicornFy.binance_com_websocket(received_stream_data_json)
-        elif exchange == "binance.com-futures":
+        elif exchange == "binance.com-futures" or exchange == "binance.com-futures-testnet":
             unicorn_fied_stream_data = UnicornFy.binance_com_futures_websocket(received_stream_data_json)
-        elif exchange == "binance.com-margin":
+        elif exchange == "binance.com-margin" or exchange == "binance.com-margin-testnet":
             unicorn_fied_stream_data = UnicornFy.binance_com_margin_websocket(received_stream_data_json)
-        elif exchange == "binance.com-isolated_margin":
+        elif exchange == "binance.com-isolated_margin" or exchange == "binance.com-isolated_margin-testnet":
             unicorn_fied_stream_data = UnicornFy.binance_com_margin_websocket(received_stream_data_json)
         elif exchange == "binance.je":
             unicorn_fied_stream_data = UnicornFy.binance_je_websocket(received_stream_data_json)

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,9 @@ setuptools.setup(
      version='1.17.4.dev',
      author="Oliver Zehentleitner",
      url="https://about.me/oliver-zehentleitner/",
-     description="An unofficial Python API to use the Binance Websocket API`s (com, com-margin, com-isolated_margin, "
-                 "com-futures, jersey, us, jex, dex/chain+testnet) in a easy, fast, flexible, robust and fully-featured"
-                 " way.",
+     description="An unofficial Python API to use the Binance Websocket API`s (com+testnet, com-margin+testnet, "
+                 "com-isolated_margin+testnet, com-futures+testnet, jersey, us, jex, dex/chain+testnet) in a easy, fast"
+                 ", flexible, robust and fully-featured way.",
      long_description=long_description,
      long_description_content_type="text/markdown",
      license='MIT License',

--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_manager.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_manager.py
@@ -59,8 +59,9 @@ import uuid
 
 class BinanceWebSocketApiManager(threading.Thread):
     """
-    A python API to use the Binance Websocket API`s (com, com-margin, com-futures, jersey, us, dex/chain+testnet) in a
-    easy, fast, flexible, robust and fully-featured way.
+    An unofficial Python API to use the Binance Websocket API`s (com+testnet, com-margin+testnet,
+    com-isolated_margin+testnet, com-futures+testnet, jersey, us, jex, dex/chain+testnet) in a easy, fast, flexible,
+    robust and fully-featured way.
 
     This library supports two different kind of websocket endpoints:
 
@@ -104,8 +105,10 @@ class BinanceWebSocketApiManager(threading.Thread):
                                 get stored in the stream_buffer! (How to read from stream_buffer:
                                 https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/README.html#and-4-more-lines-to-print-the-receives)
     :type process_stream_data: function
-    :param exchange: Select binance.com, binance.com-margin, binance.com-isolated_margin, binance.com-futures,
-                     binance.je, binance.us, jex.com, binance.org or binance.org-testnet (default: binance.com)
+    :param exchange: Select binance.com, binance.com-testnet, binance.com-margin, binance.com-margin-testnet,
+                     binance.com-isolated_margin, binance.com-isolated_margin-testnet, binance.com-futures,
+                     binance.com-futures-testnet, binance.je, binance.us, jex.com, binance.org or binance.org-testnet
+                     (default: binance.com)
     :type exchange: str
     :param warn_on_update: set to `False` to disable the update warning
     :type warn_on_update: bool
@@ -136,31 +139,30 @@ class BinanceWebSocketApiManager(threading.Thread):
             self.process_stream_data = process_stream_data
         self.exchange = exchange
         if self.exchange == "binance.com":
-            # Binance: www.binance.com
             self.websocket_base_uri = "wss://stream.binance.com:9443/"
+        elif self.exchange == "binance.com-testnet":
+            self.websocket_base_uri = "wss://testnet.binance.vision/"
         elif self.exchange == "binance.com-margin":
-            # Binance Margin: www.binance.com
             self.websocket_base_uri = "wss://stream.binance.com:9443/"
+        elif self.exchange == "binance.com-margin-testnet":
+            self.websocket_base_uri = "wss://testnet.binance.vision/"
         elif self.exchange == "binance.com-isolated_margin":
-            # Binance Isolated Margin: www.binance.com
             self.websocket_base_uri = "wss://stream.binance.com:9443/"
+        elif self.exchange == "binance.com-isolated_margin-testnet":
+            self.websocket_base_uri = "wss://testnet.binance.vision/"
         elif self.exchange == "binance.com-futures":
-            # Binance Futures: www.binance.com
             self.websocket_base_uri = "wss://fstream.binance.com/"
+        elif self.exchange == "binance.com-futures-testnet":
+            self.websocket_base_uri = "wss://stream.binancefuture.com/"
         elif self.exchange == "binance.je":
-            # Binance Jersey: www.binance.je
             self.websocket_base_uri = "wss://stream.binance.je:9443/"
         elif self.exchange == "binance.us":
-            # Binance US: www.binance.us
             self.websocket_base_uri = "wss://stream.binance.us:9443/"
         elif self.exchange == "jex.com":
-            # Binance JEX: www.jex.com
             self.websocket_base_uri = "wss://ws.jex.com/"
         elif self.exchange == "binance.org":
-            # Binance Chain: www.binance.org
             self.websocket_base_uri = "wss://dex.binance.org/api/"
         elif self.exchange == "binance.org-testnet":
-            # Binance Chain Testnet: www.binance.org
             self.websocket_base_uri = "wss://testnet-dex.binance.org/api/"
         else:
             # Unknown Exchange

--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_manager.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_manager.py
@@ -2010,9 +2010,13 @@ class BinanceWebSocketApiManager(threading.Thread):
                 self.exchange == "binance.org-testnet":
             is_type = "dex"
         elif self.exchange == "binance.com" or \
+                self.exchange == "binance.com-testnet" or \
                 self.exchange == "binance.com-margin" or \
+                self.exchange == "binance.com-margin-testnet" or \
                 self.exchange == "binance.com-isolated_margin" or \
+                self.exchange == "binance.com-isolated_margin-testnet" or \
                 self.exchange == "binance.com-futures" or \
+                self.exchange == "binance.com-futures-testnet" or \
                 self.exchange == "binance.je" or \
                 self.exchange == "binance.us" or \
                 self.exchange == "jex.com":

--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_manager.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_manager.py
@@ -1509,7 +1509,7 @@ class BinanceWebSocketApiManager(threading.Thread):
         stream_buffer_items, stream_buffer_mb, reconnects, uptime
 
         :param check_command_version: is the version of the calling check_command (https://github.com/LUCIT-Development/check_lucit_collector.py)
-        :type check_command_version: str
+        :type check_command_version: False or str
         :param warn_on_update: set to `False` to disable the update warning
         :type warn_on_update: bool
         :return: dict
@@ -2424,8 +2424,9 @@ class BinanceWebSocketApiManager(threading.Thread):
                     " total_receiving_speed: " + str(received_bytes_per_x_row) + "\r\n" +
                     " total_transmitted_payloads: " + str(self.total_transmitted) + "\r\n" +
                     str(binance_api_status_row) +
-                    " process_ressource_usage: cpu=" + str(self.get_process_usage_cpu()) + "%, memory=" + str(self.get_process_usage_memory()) + ", threads=" + str(self.get_process_usage_threads()) + "\r\n" +
-                    str(add_string) +
+                    " process_ressource_usage: cpu=" + str(self.get_process_usage_cpu()) + "%, memory=" +
+                    str(self.get_process_usage_memory()) + ", threads=" + str(self.get_process_usage_threads()) +
+                    "\r\n" + str(add_string) +
                     " ---------------------------------------------------------------------------------------------\r\n"
                     "               stream_id              |   stream_label  |  last  |  average  |  most  | recon\r\n"
                     " ---------------------------------------------------------------------------------------------\r\n"

--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_restclient.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_restclient.py
@@ -54,14 +54,26 @@ class BinanceWebSocketApiRestclient(object):
         if self.exchange == "binance.com":
             self.restful_base_uri = "https://api.binance.com/"
             self.path_userdata = "api/v3/userDataStream"
+        elif self.exchange == "binance.com-testnet":
+            self.restful_base_uri = "https://testnet.binance.vision/"
+            self.path_userdata = "api/v3/userDataStream"
         elif self.exchange == "binance.com-margin":
             self.restful_base_uri = "https://api.binance.com/"
+            self.path_userdata = "sapi/v1/userDataStream"
+        elif self.exchange == "binance.com-margin-testnet":
+            self.restful_base_uri = "https://testnet.binance.vision/"
             self.path_userdata = "sapi/v1/userDataStream"
         elif self.exchange == "binance.com-isolated_margin":
             self.restful_base_uri = "https://api.binance.com/"
             self.path_userdata = "sapi/v1/userDataStream/isolated"
+        elif self.exchange == "binance.com-isolated_margin-testnet":
+            self.restful_base_uri = "https://testnet.binance.vision/"
+            self.path_userdata = "sapi/v1/userDataStream/isolated"
         elif self.exchange == "binance.com-futures":
             self.restful_base_uri = "https://fapi.binance.com/"
+            self.path_userdata = "fapi/v1/listenKey"
+        elif self.exchange == "binance.com-futures-testnet":
+            self.restful_base_uri = "https://testnet.binancefuture.com/"
             self.path_userdata = "fapi/v1/listenKey"
         elif self.exchange == "binance.je":
             self.restful_base_uri = "https://api.binance.je/"

--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_restclient.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_restclient.py
@@ -192,7 +192,7 @@ class BinanceWebSocketApiRestclient(object):
         """
         logging.info("BinanceWebSocketApiRestclient->get_listen_key() symbol=" + str(self.symbol))
         method = "post"
-        if self.exchange == "binance.com-isolated_margin":
+        if self.exchange == "binance.com-isolated_margin" or self.exchange == "binance.com-isolated_margin-testnet":
             if self.symbol is False:
                 logging.critical("BinanceWebSocketApiRestclient->get_listen_key() Info: Parameter `symbol` is missing!")
                 return False

--- a/unittest_binance_websocket_api.py
+++ b/unittest_binance_websocket_api.py
@@ -111,6 +111,66 @@ class TestBinanceComManager(unittest.TestCase):
         self.binance_com_websocket_api_manager.stop_manager_with_all_streams()
 
 
+class TestBinanceComManager(unittest.TestCase):
+    # Test testnet.binance.vision (Binance Testnet)
+
+    def setUp(self):
+        self.binance_com_testnet_api_key = BINANCE_COM_API_KEY
+        self.binance_com_testnet_api_secret = BINANCE_COM_API_SECRET
+        self.binance_com_testnet_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com-testnet")
+
+    def test_create_uri_miniticker_regular_com(self):
+        self.assertEqual(self.binance_com_testnet_websocket_api_manager.create_websocket_uri(["!miniTicker"], ["arr"]),
+                         'wss://testnet.binance.vision/ws/!miniTicker@arr')
+
+    def test_create_uri_miniticker_reverse_com(self):
+        self.assertEqual(self.binance_com_testnet_websocket_api_manager.create_websocket_uri(["arr"], ["!miniTicker"]),
+                         'wss://testnet.binance.vision/ws/!miniTicker@arr')
+
+    def test_create_uri_ticker_regular_com(self):
+        self.assertEqual(self.binance_com_testnet_websocket_api_manager.create_websocket_uri(["!ticker"], ["arr"]),
+                         'wss://testnet.binance.vision/ws/!ticker@arr')
+
+    def test_create_uri_ticker_reverse_com(self):
+        self.assertEqual(self.binance_com_testnet_websocket_api_manager.create_websocket_uri(["arr"], ["!ticker"]),
+                         'wss://testnet.binance.vision/ws/!ticker@arr')
+
+    def test_create_uri_userdata_regular_false_com(self):
+        self.assertFalse(self.binance_com_testnet_websocket_api_manager.create_websocket_uri(["!userData"], ["arr"]))
+
+    def test_create_uri_userdata_reverse_false_com(self):
+        self.assertFalse(self.binance_com_testnet_websocket_api_manager.create_websocket_uri(["arr"], ["!userData"]))
+
+    def test_create_uri_userdata_regular_com(self):
+        if len(self.binance_com_testnet_api_key) == 0 or len(self.binance_com_testnet_api_secret) == 0:
+            print("\r\nempty API key and/or secret: can not successfully test test_create_uri_userdata_regular_com() "
+                  "for binance.com-testnet")
+        else:
+            stream_id = uuid.uuid4()
+            self.binance_com_testnet_websocket_api_manager._add_socket_to_socket_list(stream_id, ["!userData"], ["arr"])
+            self.assertRegex(self.binance_com_testnet_websocket_api_manager.create_websocket_uri(["!userData"], ["arr"],
+                                                                                         stream_id,
+                                                                                         self.binance_com_testnet_api_key,
+                                                                                         self.binance_com_testnet_api_secret),
+                             r'wss://testnet.binance.vision/ws/.')
+
+    def test_create_uri_userdata_reverse_com(self):
+        if len(self.binance_com_testnet_api_key) == 0 or len(self.binance_com_testnet_api_secret) == 0:
+            print("\r\nempty API key and/or secret: can not successfully test test_create_uri_userdata_reverse_com() "
+                  "for binance.com-testnet")
+        else:
+            stream_id = uuid.uuid4()
+            self.binance_com_testnet_websocket_api_manager._add_socket_to_socket_list(stream_id, ["arr"], ["!userData"])
+            self.assertRegex(self.binance_com_testnet_websocket_api_manager.create_websocket_uri(["arr"], ["!userData"],
+                                                                                         stream_id,
+                                                                                         self.binance_com_testnet_api_key,
+                                                                                         self.binance_com_testnet_api_secret),
+                             r'wss://stream.binance.com:9443/ws/.')
+
+    def tearDown(self):
+        self.binance_com_testnet_websocket_api_manager.stop_manager_with_all_streams()
+
+
 class TestBinanceJeManager(unittest.TestCase):
     # Test binance.je (Binance Jersey)
 

--- a/unittest_binance_websocket_api.py
+++ b/unittest_binance_websocket_api.py
@@ -107,11 +107,17 @@ class TestBinanceComManager(unittest.TestCase):
                                                                                          self.binance_com_api_secret),
                              r'wss://stream.binance.com:9443/ws/.')
 
+    def test_is_exchange_type_cex(self):
+        self.assertEqual(self.binance_com_websocket_api_manager.is_exchange_type("cex"), True)
+
+    def test_is_exchange_type_dex(self):
+        self.assertEqual(self.binance_com_websocket_api_manager.is_exchange_type("dex"), False)
+
     def tearDown(self):
         self.binance_com_websocket_api_manager.stop_manager_with_all_streams()
 
 
-class TestBinanceComManager(unittest.TestCase):
+class TestBinanceComManagerTest(unittest.TestCase):
     # Test testnet.binance.vision (Binance Testnet)
 
     def setUp(self):
@@ -166,6 +172,12 @@ class TestBinanceComManager(unittest.TestCase):
                                                                                          self.binance_com_testnet_api_key,
                                                                                          self.binance_com_testnet_api_secret),
                              r'wss://stream.binance.com:9443/ws/.')
+
+    def test_is_exchange_type_cex(self):
+        self.assertEqual(self.binance_com_testnet_websocket_api_manager.is_exchange_type("cex"), True)
+
+    def test_is_exchange_type_dex(self):
+        self.assertEqual(self.binance_com_testnet_websocket_api_manager.is_exchange_type("dex"), False)
 
     def tearDown(self):
         self.binance_com_testnet_websocket_api_manager.stop_manager_with_all_streams()
@@ -227,6 +239,12 @@ class TestBinanceJeManager(unittest.TestCase):
                                                                                         self.binance_je_api_key,
                                                                                         self.binance_je_api_secret),
                              r'wss://stream.binance.je:9443/ws')
+
+    def test_is_exchange_type_cex(self):
+        self.assertEqual(self.binance_je_websocket_api_manager.is_exchange_type("cex"), True)
+
+    def test_is_exchange_type_dex(self):
+        self.assertEqual(self.binance_je_websocket_api_manager.is_exchange_type("dex"), False)
 
     def tearDown(self):
         self.binance_je_websocket_api_manager.stop_manager_with_all_streams()
@@ -362,6 +380,12 @@ class TestBinanceOrgManager(unittest.TestCase):
         self.assertEqual(str(payload),
                          "[{'method': 'unsubscribe', 'symbols': ['RAVEN-F66_BNB']}, "
                          "{'method': 'unsubscribe', 'topic': 'trades'}]")
+
+    def test_is_exchange_type_cex(self):
+        self.assertEqual(self.binance_org_websocket_api_manager.is_exchange_type("cex"), False)
+
+    def test_is_exchange_type_dex(self):
+        self.assertEqual(self.binance_org_websocket_api_manager.is_exchange_type("dex"), True)
 
     def tearDown(self):
         self.binance_org_websocket_api_manager.stop_manager_with_all_streams()

--- a/unittest_binance_websocket_api.py
+++ b/unittest_binance_websocket_api.py
@@ -113,6 +113,21 @@ class TestBinanceComManager(unittest.TestCase):
     def test_is_exchange_type_dex(self):
         self.assertEqual(self.binance_com_websocket_api_manager.is_exchange_type("dex"), False)
 
+    def test_is_update_available(self):
+        self.assertEqual(self.binance_com_websocket_api_manager.is_update_availabe(), False)
+
+    def test_is_manager_stopping(self):
+        self.assertEqual(self.binance_com_websocket_api_manager.is_manager_stopping(), False)
+
+    def test_get_human_uptime(self):
+        self.assertEqual(self.binance_com_websocket_api_manager.get_human_uptime(3737823782), "43261d:20h:23m:2s")
+
+    def test_get_human_bytesize(self):
+        self.assertEqual(self.binance_com_websocket_api_manager.get_human_bytesize(99999993737823782), "90949.464 tB")
+
+    def test_get_exchange(self):
+        self.assertEqual(self.binance_com_websocket_api_manager.get_exchange(), "binance.com")
+
     def tearDown(self):
         self.binance_com_websocket_api_manager.stop_manager_with_all_streams()
 


### PR DESCRIPTION
Adding Testnet endpoints for spot, margin, isolated_margin and futures!

Request: https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/115