### PR TITLE
Cannot use `in` with RuntimeError, must convert to string first.

### DIFF
--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_manager.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_manager.py
@@ -432,7 +432,7 @@ class BinanceWebSocketApiManager(threading.Thread):
         try:
             loop.run_until_complete(socket.start_socket())
         except RuntimeError as error_msg:
-            if "cannot schedule new futures after interpreter shutdown" in error_msg:
+            if "cannot schedule new futures after interpreter shutdown" in str(error_msg):
                 logging.critical(f"BinanceWebSocketApiManager._create_stream_thread() stream_id={str(stream_id)} "
                                  f" - RuntimeError error_msg:  - {str(error_msg)} - stopping and shutting down ...")
                 self.stop_manager_with_all_streams()


### PR DESCRIPTION
# PR Details

`TypeError: argument of type 'RuntimeError' is not iterable` was being raised.

This is because you cannot use `in` with RuntimeError, must convert to string first. Additionally, you can use an equal sign, but may desire `in` instead.

## Description

Converted RuntimeError to string.

## How Has This Been Tested

I'm receiving this RuntimeError after updating to Py3.9 and latest unicorn-binance-websocket-api, so now this exception is succesfully printed and program exited.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [x ] I have read the 
**[CONTRIBUTING](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/blob/master/CONTRIBUTING.md)** 
document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
