### PR TITLE
Add support for Binance Coin-M futures via binance.com-coin-futures exchange type

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ on, you can to use the [UNICORN Binance REST API](https://github.com/oliver-zehe
 | [Binance Margin Testnet](https://testnet.binance.vision/) | `BinanceWebSocketApiManager(exchange="binance.com-margin-testnet")` |
 | [Binance Isolated Margin](https://www.binance.com) | `BinanceWebSocketApiManager(exchange="binance.com-isolated_margin")` |
 | [Binance Isolated Margin Testnet](https://testnet.binance.vision/) | `BinanceWebSocketApiManager(exchange="binance.com-isolated_margin-testnet")` |
-| [Binance Futures](https://www.binance.com) | `BinanceWebSocketApiManager(exchange="binance.com-futures")` |
-| [Binance Futures Testnet](https://testnet.binancefuture.com) | `BinanceWebSocketApiManager(exchange="binance.com-futures-testnet")` |
+| [Binance USD-M Futures](https://www.binance.com) | `BinanceWebSocketApiManager(exchange="binance.com-futures")` |
+| [Binance USD-M Futures Testnet](https://testnet.binancefuture.com) | `BinanceWebSocketApiManager(exchange="binance.com-futures-testnet")` |
+| [Binance Coin-M Futures](https://www.binance.com) | `BinanceWebSocketApiManager(exchange="binance.com-coin-futures")` |
 | [Binance Jersey](https://www.binance.je) | `BinanceWebSocketApiManager(exchange="binance.je")` |
 | [Binance US](https://www.binance.us) | `BinanceWebSocketApiManager(exchange="binance.us")` |
 | [Binance TR](https://www.trbinance.com) | `BinanceWebSocketApiManager(exchange="trbinance.com")` |

--- a/docs/README.html
+++ b/docs/README.html
@@ -204,12 +204,16 @@ on, you have to use the Binance Rest API (<a class="reference external" href="ht
 <td><code>BinanceWebSocketApiManager(exchange="binance.com-isolated_margin-testnet")</code></td>
 </tr>
 <tr>
-<td><a href="https://www.binance.com">Binance Futures</a></td>
+<td><a href="https://www.binance.com">Binance USD-M Futures</a></td>
 <td><code>BinanceWebSocketApiManager(exchange="binance.com-futures")</code></td>
 </tr>
 <tr>
 <td><a href="https://testnet.binancefuture.com">Binance Futures Testnet</a></td>
 <td><code>BinanceWebSocketApiManager(exchange="binance.com-futures-testnet")</code></td>
+</tr>
+<tr>
+<td><a href="https://www.binance.com">Binance Coin-M Futures</a></td>
+<td><code>BinanceWebSocketApiManager(exchange="binance.com-coin-futures")</code></td>
 </tr>
 <tr>
 <td><a href="https://www.binance.je">Binance Jersey</a></td>

--- a/docs/unicorn_binance_websocket_api.html
+++ b/docs/unicorn_binance_websocket_api.html
@@ -169,7 +169,7 @@ like <cite>process_stream_data(stream_data, stream_buffer_name)</cite> where
 get stored in the stream_buffer! <a class="reference external" href="https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/README.html#and-4-more-lines-to-print-the-receives">How to read from stream_buffer!</a></p></li>
 <li><p><strong>exchange</strong> (<em>str</em>) – Select binance.com, binance.com-testnet, binance.com-margin, binance.com-margin-testnet,
 binance.com-isolated_margin, binance.com-isolated_margin-testnet, binance.com-futures,
-binance.com-futures-testnet, binance.je, binance.us, trbinance.com, jex.com, binance.org or
+binance.com-futures-testnet, binance.com-coin-futures, binance.je, binance.us, trbinance.com, jex.com, binance.org or
 binance.org-testnet (default: binance.com)</p></li>
 <li><p><strong>warn_on_update</strong> (<em>bool</em>) – set to <cite>False</cite> to disable the update warning</p></li>
 <li><p><strong>throw_exception_if_unrepairable</strong> (<em>bool</em>) – set to <cite>True</cite> to activate exceptions if a crashed stream is unrepairable

--- a/example_binance_coin_futures.py
+++ b/example_binance_coin_futures.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# File: example_binance_futures.py
+#
+# Part of ‘UNICORN Binance WebSocket API’
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api
+# PyPI: https://pypi.org/project/unicorn-binance-websocket-api/
+#
+# Author: Oliver Zehentleitner
+#         https://about.me/oliver-zehentleitner
+#
+# Copyright (c) 2019-2021, Oliver Zehentleitner
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+from unicorn_binance_websocket_api.unicorn_binance_websocket_api_manager import BinanceWebSocketApiManager
+import logging
+import time
+import threading
+import os
+
+# https://docs.python.org/3/library/logging.html#logging-levels
+logging.basicConfig(level=logging.DEBUG,
+                    filename=os.path.basename(__file__) + '.log',
+                    format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
+                    style="{")
+
+
+def print_stream_data_from_stream_buffer(binance_websocket_api_manager):
+    while True:
+        if binance_websocket_api_manager.is_manager_stopping():
+            exit(0)
+        oldest_stream_data_from_stream_buffer = binance_websocket_api_manager.pop_stream_data_from_stream_buffer()
+        if oldest_stream_data_from_stream_buffer is False:
+            time.sleep(0.01)
+
+# create instance of BinanceWebSocketApiManager for Binance.com Futures
+binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com-coin-futures")
+
+# set api key and secret for userData stream
+binance_je_api_key = ""
+binance_je_api_secret = ""
+userdata_stream_id = binance_websocket_api_manager.create_stream(["arr"],
+                                                                 ["!userData"],
+                                                                 api_key=binance_je_api_key,
+                                                                 api_secret=binance_je_api_secret)
+
+bookticker_all_stream_id = binance_websocket_api_manager.create_stream(["arr"], ["!bookTicker"])
+
+# https://binance-docs.github.io/apidocs/delivery/en/#mark-price-of-all-symbols-of-a-pair
+stream_id = binance_websocket_api_manager.create_stream(["markPrice@1s"], "btcusd", stream_label="BTCUSD@arr@1s")
+
+symbols = {'btcusd_perp', 'ethusd_perp', 'bnbusd_perp'}
+pairs = {'btcusd', 'ethusd', 'bnbusd'}
+binance_websocket_api_manager.create_stream(["aggTrade"], symbols)
+binance_websocket_api_manager.create_stream(["markPrice"], pairs)
+binance_websocket_api_manager.create_stream(["markPriceKline_1m"], symbols)
+binance_websocket_api_manager.create_stream(["indexPriceKline_5m"], symbols)
+binance_websocket_api_manager.create_stream(["depth5@100ms"], symbols)
+binance_websocket_api_manager.create_stream(["depth10"], symbols)
+
+# start a worker process to move the received stream_data from the stream_buffer to a print function
+worker_thread = threading.Thread(target=print_stream_data_from_stream_buffer, args=(binance_websocket_api_manager,))
+worker_thread.start()
+
+# show an overview
+while True:
+    binance_websocket_api_manager.print_summary()
+    time.sleep(1)

--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_manager.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_manager.py
@@ -118,8 +118,8 @@ class BinanceWebSocketApiManager(threading.Thread):
     :type process_stream_data: function
     :param exchange: Select binance.com, binance.com-testnet, binance.com-margin, binance.com-margin-testnet,
                      binance.com-isolated_margin, binance.com-isolated_margin-testnet, binance.com-futures,
-                     binance.com-futures-testnet, binance.je, binance.us, trbinance.com, jex.com, binance.org or
-                     binance.org-testnet (default: binance.com)
+                     binance.com-futures-testnet, binance.com-coin-futures, binance.je, binance.us, trbinance.com,
+                     jex.com, binance.org or binance.org-testnet (default: binance.com)
     :type exchange: str
     :param warn_on_update: set to `False` to disable the update warning
     :type warn_on_update: bool
@@ -191,6 +191,9 @@ class BinanceWebSocketApiManager(threading.Thread):
             self.max_subscriptions_per_stream = 1024
         elif self.exchange == "binance.com-futures":
             self.websocket_base_uri = "wss://fstream.binance.com/"
+            self.max_subscriptions_per_stream = 200
+        elif self.exchange == "binance.com-coin-futures":
+            self.websocket_base_uri = "wss://dstream.binance.com/"
             self.max_subscriptions_per_stream = 200
         elif self.exchange == "binance.com-futures-testnet":
             self.websocket_base_uri = "wss://stream.binancefuture.com/"
@@ -2395,6 +2398,7 @@ class BinanceWebSocketApiManager(threading.Thread):
                 self.exchange == "binance.com-isolated_margin-testnet" or \
                 self.exchange == "binance.com-futures" or \
                 self.exchange == "binance.com-futures-testnet" or \
+                self.exchange == "binance.com-coin-futures" or \
                 self.exchange == "binance.je" or \
                 self.exchange == "binance.us" or \
                 self.exchange == "trbinance.com" or \

--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_restclient.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_restclient.py
@@ -81,6 +81,9 @@ class BinanceWebSocketApiRestclient(object):
         elif self.manager.exchange == "binance.com-futures-testnet":
             self.restful_base_uri = "https://testnet.binancefuture.com/"
             self.path_userdata = "fapi/v1/listenKey"
+        elif self.manager.exchange == "binance.com-coin-futures":
+            self.restful_base_uri = "https://dapi.binance.com/"
+            self.path_userdata = "dapi/v1/listenKey"
         elif self.manager.exchange == "binance.je":
             self.restful_base_uri = "https://api.binance.je/"
             self.path_userdata = "api/v1/userDataStream"

--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_socket.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_socket.py
@@ -126,6 +126,7 @@ class BinanceWebSocketApiSocket(object):
                                 received_stream_data = self.unicorn_fy.binance_com_futures_websocket(received_stream_data_json)
                             elif self.exchange == "binance.com-futures-testnet":
                                 received_stream_data = self.unicorn_fy.binance_com_futures_websocket(received_stream_data_json)
+                            # TODO coin margined futures (What to do about it?)
                             elif self.exchange == "binance.je":
                                 received_stream_data = self.unicorn_fy.binance_je_websocket(received_stream_data_json)
                             elif self.exchange == "binance.us":

--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_socket.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_socket.py
@@ -126,7 +126,8 @@ class BinanceWebSocketApiSocket(object):
                                 received_stream_data = self.unicorn_fy.binance_com_futures_websocket(received_stream_data_json)
                             elif self.exchange == "binance.com-futures-testnet":
                                 received_stream_data = self.unicorn_fy.binance_com_futures_websocket(received_stream_data_json)
-                            # TODO coin margined futures (What to do about it?)
+                            elif self.exchange == "binance.com-coin-futures":
+                                received_stream_data = self.unicorn_fy.binance_com_coin_futures_websocket(received_stream_data_json)
                             elif self.exchange == "binance.je":
                                 received_stream_data = self.unicorn_fy.binance_je_websocket(received_stream_data_json)
                             elif self.exchange == "binance.us":

--- a/unittest_binance_websocket_api.py
+++ b/unittest_binance_websocket_api.py
@@ -544,13 +544,18 @@ class TestRestApi(unittest.TestCase):
         BinanceWebSocketApiRestclient(binance_websocket_api_manager)
         binance_websocket_api_manager.stop_manager_with_all_streams()
 
-    def test_rest_binance_com_futures_testnet(self):
+    def test_rest_binance_com_futures(self):
         binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com-futures")
         BinanceWebSocketApiRestclient(binance_websocket_api_manager)
         binance_websocket_api_manager.stop_manager_with_all_streams()
 
     def test_rest_binance_com_futures_testnet(self):
         binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com-futures-testnet")
+        BinanceWebSocketApiRestclient(binance_websocket_api_manager)
+        binance_websocket_api_manager.stop_manager_with_all_streams()
+
+    def test_rest_binance_com_coin_futures(self):
+        binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com-futures")
         BinanceWebSocketApiRestclient(binance_websocket_api_manager)
         binance_websocket_api_manager.stop_manager_with_all_streams()
 

--- a/unittest_binance_websocket_api.py
+++ b/unittest_binance_websocket_api.py
@@ -555,7 +555,7 @@ class TestRestApi(unittest.TestCase):
         binance_websocket_api_manager.stop_manager_with_all_streams()
 
     def test_rest_binance_com_coin_futures(self):
-        binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com-futures")
+        binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com-coin-futures")
         BinanceWebSocketApiRestclient(binance_websocket_api_manager)
         binance_websocket_api_manager.stop_manager_with_all_streams()
 


### PR DESCRIPTION
# PR Details

Add basic support for coin margin futures web sockets.

## Description

- Add new `binance.com-coin-futures` exchange type for wss://dstream.binance.com/ base uri
- Add usage example for coin m futures websocket streams
- Updated documentation
- Extended unit tests
- Fixed bug in unit tests

## Related Issue

https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/134

## Motivation and Context

I like the project, but I need coin margin futures :man_shrugging:

## How Has This Been Tested

Tested with the newly introduced example and by running other test examples with the changes with a Linux machine and my own Binance account. I transferred funds to my coin-m futures account to test the user data stream events.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the 
**[CONTRIBUTING](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/blob/master/CONTRIBUTING.md)** 
document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
