### PR TITLE
Correctly scope logging

### DIFF
--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_connection.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_connection.py
@@ -43,6 +43,8 @@ import time
 import websockets
 
 connect = websockets.connect
+logger = logging.getLogger(__name__)
+
 
 
 class BinanceWebSocketApiConnection(object):
@@ -78,7 +80,7 @@ class BinanceWebSocketApiConnection(object):
         if uri is False:
             # cant get a valid URI, so this stream has to crash
             error_msg = "Probably no internet connection?"
-            logging.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
+            logger.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
                              str(self.channels) + ", " + str(self.markets) + ") - " + " error: 5 - " + str(error_msg))
             self.manager.stream_is_crashing(self.stream_id, str(error_msg))
             self.manager.set_restart_request(self.stream_id)
@@ -97,21 +99,21 @@ class BinanceWebSocketApiConnection(object):
                     # -2015 = Invalid API-key, IP, or permissions for action
                     # -11001 = Isolated margin account does not exist.
                     # Cant get a valid listen_key, so this stream has to crash:
-                    logging.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
+                    logger.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
                                      ", " + str(self.channels) + ", " + str(self.markets) + ") - error: 4 - " +
                                      str(uri['msg']))
                     try:
                         del self.manager.restart_requests[self.stream_id]
                     except KeyError as error_msg:
-                        logging.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
+                        logger.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
                                          ", " + str(self.channels) + ", " + str(self.markets) + ") - error: 6 - "
                                          + str(error_msg))
                     except TypeError as error_msg:
-                        logging.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
+                        logger.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
                                          ", " + str(self.channels) + ", " + str(self.markets) + ") - error: 3 - "
                                          + str(error_msg))
                 else:
-                    logging.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
+                    logger.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
                                      ", " + str(self.channels) + ", " + str(self.markets) + ") -  Received unknown"
                                      " error msg from Binance: " + str(uri['msg']))
                 self.manager.stream_is_crashing(self.stream_id, str(uri['msg']))
@@ -119,7 +121,7 @@ class BinanceWebSocketApiConnection(object):
                     raise StreamRecoveryError("stream_id " + str(self.stream_id) + ": " + str(uri))
                 sys.exit(1)
         except KeyError as error_msg:
-            logging.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
+            logger.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
                              ", " + str(self.channels) + ", " + str(self.markets) + ") - error: 1 - "
                              + str(error_msg))
 
@@ -146,7 +148,7 @@ class BinanceWebSocketApiConnection(object):
             try:
                 self.manager.websocket_list[self.stream_id] = await self._conn.__aenter__()
             except websockets.exceptions.InvalidMessage as error_msg:
-                logging.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
+                logger.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
                               ", " + str(self.channels) + ", " + str(self.markets) + ") - InvalidMessage error_msg:  " +
                               str(error_msg))
                 self.manager.stream_is_crashing(self.stream_id, str(error_msg))
@@ -155,7 +157,7 @@ class BinanceWebSocketApiConnection(object):
                 sys.exit(1)
             except websockets.exceptions.InvalidStatusCode as error_msg:
                 if "HTTP 429" in str(error_msg):
-                    logging.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
+                    logger.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
                                   ", " + str(self.channels) + ", " + str(self.markets) + ") InvalidStatusCode-HTTP429" +
                                   str(error_msg))
                     self.manager.stream_is_crashing(self.stream_id, str(error_msg))
@@ -163,7 +165,7 @@ class BinanceWebSocketApiConnection(object):
                     self.manager.set_restart_request(self.stream_id)
                     sys.exit(1)
                 else:
-                    logging.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
+                    logger.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
                                   ", " + str(self.channels) + ", " + str(self.markets) + ") - InvalidStatusCode" +
                                   " error_msg: " + str(error_msg))
             self.manager.stream_list[self.stream_id]['status'] = "running"
@@ -177,22 +179,22 @@ class BinanceWebSocketApiConnection(object):
             self.manager.set_heartbeat(self.stream_id)
             self.manager.process_stream_signals("CONNECT", self.stream_id)
         except websockets.exceptions.NegotiationError as error_msg:
-            logging.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
+            logger.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
                           str(self.channels) + ", " + str(self.markets) + ")" + " - NegotiationError - " +
                           "error_msg: " + str(error_msg))
         except ConnectionResetError as error_msg:
-            logging.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
+            logger.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
                           str(self.channels) + ", " + str(self.markets) + ")" + " - ConnectionResetError - " +
                           "error_msg: " + str(error_msg))
         except socket.gaierror as error_msg:
-            logging.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
+            logger.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
                              str(self.channels) + ", " + str(self.markets) + ")" + " - No internet connection? "
                              "- error_msg: " + str(error_msg))
             self.manager.stream_is_crashing(self.stream_id, f"{str(error_msg)} - No internet connection?")
             self.manager.set_restart_request(self.stream_id)
             sys.exit(1)
         except OSError as error_msg:
-            logging.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
+            logger.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
                              str(self.channels) + ", " + str(self.markets) + ")" + " - OSError - error_msg: " +
                              str(error_msg))
             self.manager.stream_is_crashing(self.stream_id, (str(error_msg)))
@@ -202,7 +204,7 @@ class BinanceWebSocketApiConnection(object):
             if "Status code not 101: 414" in str(error_msg):
                 # Since we subscribe via websocket.send() and not with URI anymore, this is obsolete code I guess.
                 self.manager.stream_is_crashing(self.stream_id, str(error_msg) + " --> URI too long?")
-                logging.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
+                logger.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
                                  str(self.channels) + ", " + str(self.markets) + ")" + " - URI Too Long? - error_msg: "
                                  + str(error_msg))
                 try:
@@ -211,22 +213,22 @@ class BinanceWebSocketApiConnection(object):
                     pass
                 sys.exit(1)
             elif "Status code not 101: 400" in str(error_msg):
-                logging.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
+                logger.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
                                  str(self.channels) + ", " + str(self.markets) + ") - error_msg: " + str(error_msg))
             elif "Status code not 101: 429" in str(error_msg):
-                logging.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
+                logger.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
                               str(self.channels) + ", " + str(self.markets) + ") - error_msg: " + str(error_msg))
                 self.manager.stream_is_crashing(self.stream_id, str(error_msg))
                 time.sleep(2)
                 self.manager.set_restart_request(self.stream_id)
                 sys.exit(1)
             elif "Status code not 101: 500" in str(error_msg):
-                logging.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
+                logger.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
                                  str(self.channels) + ", " + str(self.markets) + ") - error_msg: " + str(error_msg))
                 self.manager.stream_is_crashing(self.stream_id, str(error_msg))
                 sys.exit(1)
             else:
-                logging.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
+                logger.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
                               str(self.channels) + ", " + str(self.markets) + ") - error_msg: " + str(error_msg))
                 try:
                     self.manager.websocket_list[self.stream_id].close()
@@ -236,7 +238,7 @@ class BinanceWebSocketApiConnection(object):
                 self.manager.set_restart_request(self.stream_id)
                 sys.exit(1)
         except websockets.exceptions.ConnectionClosed as error_msg:
-            logging.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
+            logger.error("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) + ", " +
                           str(self.channels) + ", " + str(self.markets) + ") - Exception ConnectionClosed"
                           " - error_msg:  " + str(error_msg))
             if "WebSocket connection is closed: code = 1006" in str(error_msg):
@@ -244,7 +246,7 @@ class BinanceWebSocketApiConnection(object):
                 self.manager.stream_is_crashing(self.stream_id, str(error_msg))
                 sys.exit(1)
             else:
-                logging.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
+                logger.critical("BinanceWebSocketApiConnection.await._conn.__aenter__(" + str(self.stream_id) +
                                  ", " + str(self.channels) + ", " + str(self.markets) + ") UnhandledException "
                                  "ConnectionClosed" + str(error_msg))
         return self
@@ -253,10 +255,10 @@ class BinanceWebSocketApiConnection(object):
         try:
             await self._conn.__aexit__(*args, **kwargs)
         except AttributeError as error_msg:
-            logging.error("BinanceWebSocketApiConnection.__aexit__(*args, **kwargs): "
+            logger.error("BinanceWebSocketApiConnection.__aexit__(*args, **kwargs): "
                           "AttributeError - " + str(error_msg))
         except websockets.exceptions.ConnectionClosed as error_msg:
-            logging.error("BinanceWebSocketApiConnection.__aexit__(*args, **kwargs): "
+            logger.error("BinanceWebSocketApiConnection.__aexit__(*args, **kwargs): "
                           "ConnectionClosed - " + str(error_msg))
             self.manager.stream_is_stopping(self.stream_id)
             if self.manager.is_stop_request(self.stream_id) is False and \
@@ -267,17 +269,17 @@ class BinanceWebSocketApiConnection(object):
     async def close(self):
         if self.manager.is_stop_as_crash_request(self.stream_id) is False:
             self.manager.stream_is_stopping(self.stream_id)
-        logging.info(f"BinanceWebSocketApiConnection.close({str(self.stream_id)})")
+        logger.info(f"BinanceWebSocketApiConnection.close({str(self.stream_id)})")
         try:
             await self.manager.websocket_list[self.stream_id].close()
         except KeyError:
-            logging.error(f"BinanceWebSocketApiConnection.close({str(self.stream_id)}) - Stream not found!")
+            logger.error(f"BinanceWebSocketApiConnection.close({str(self.stream_id)}) - Stream not found!")
         except RuntimeError as error_msg:
-            logging.error(f"BinanceWebSocketApiConnection.close({str(self.stream_id)}) - "
+            logger.error(f"BinanceWebSocketApiConnection.close({str(self.stream_id)}) - "
                           f"RuntimeError: {str(error_msg)}")
         except ValueError as error_msg:
             # ValueError: The future belongs to a different loop than the one specified as the loop argument
-            logging.error(f"BinanceWebSocketApiConnection.close({str(self.stream_id)}) socket_id="
+            logger.error(f"BinanceWebSocketApiConnection.close({str(self.stream_id)}) socket_id="
                           f"{str(self.socket_id)}) - Closing this socket! - ValueError: {str(error_msg)}")
             self.manager.stream_is_stopping(self.stream_id)
             if self.manager.is_stop_request(self.stream_id) is False:
@@ -301,21 +303,21 @@ class BinanceWebSocketApiConnection(object):
                 self.manager.increase_received_bytes_per_second(self.stream_id, size)
             return received_data_json
         except RuntimeError as error_msg:
-            logging.error("BinanceWebSocketApiConnection.receive(" +
+            logger.error("BinanceWebSocketApiConnection.receive(" +
                           str(self.stream_id) + ") - RuntimeError - error_msg: " + str(error_msg))
             self.manager.stream_is_stopping(self.stream_id)
             if self.manager.is_stop_request(self.stream_id) is False:
                 self.manager.set_restart_request(self.stream_id)
             sys.exit(1)
         except ssl.SSLError as error_msg:
-            logging.error("BinanceWebSocketApiConnection.receive(" +
+            logger.error("BinanceWebSocketApiConnection.receive(" +
                           str(self.stream_id) + ") - ssl.SSLError - error_msg: " + str(error_msg))
             self.manager.stream_is_stopping(self.stream_id)
             if self.manager.is_stop_request(self.stream_id) is False:
                 self.manager.set_restart_request(self.stream_id)
             sys.exit(1)
         except KeyError as error_msg:
-            logging.error("BinanceWebSocketApiConnection.receive(" +
+            logger.error("BinanceWebSocketApiConnection.receive(" +
                           str(self.stream_id) + ") - KeyError - error_msg: " + str(error_msg))
             self.manager.stream_is_stopping(self.stream_id)
             if self.manager.is_stop_request(self.stream_id) is False:
@@ -323,7 +325,7 @@ class BinanceWebSocketApiConnection(object):
             sys.exit(1)
         except ValueError as error_msg:
             # ValueError: The future belongs to a different loop than the one specified as the loop argument
-            logging.error(f"BinanceWebSocketApiConnection.receive({str(self.stream_id)}) socket_id="
+            logger.error(f"BinanceWebSocketApiConnection.receive({str(self.stream_id)}) socket_id="
                           f"{str(self.socket_id)}) - Closing this socket! - ValueError: {str(error_msg)}")
             self.manager.stream_is_stopping(self.stream_id)
             if self.manager.is_stop_request(self.stream_id) is False:
@@ -336,30 +338,30 @@ class BinanceWebSocketApiConnection(object):
             await self.manager.websocket_list[self.stream_id].send(data)
             self.manager.increase_transmitted_counter(self.stream_id)
         except websockets.exceptions.ConnectionClosed as error_msg:
-            logging.error("BinanceWebSocketApiConnection.send(" + str(self.stream_id) + ", " +
+            logger.error("BinanceWebSocketApiConnection.send(" + str(self.stream_id) + ", " +
                           str(self.channels) + ", " + str(self.markets) + ") - Exception ConnectionClosed "
                           "- error_msg:  " + str(error_msg))
             self.manager.stream_is_crashing(self.stream_id, str(error_msg))
             self.manager.set_restart_request(self.stream_id)
             sys.exit(1)
         except RuntimeError as error_msg:
-            logging.error("BinanceWebSocketApiConnection.send(" + str(self.stream_id) + ", " +
+            logger.error("BinanceWebSocketApiConnection.send(" + str(self.stream_id) + ", " +
                           str(self.channels) + ", " + str(self.markets) + ") - Exception RuntimeError "
                           "- error_msg:  " + str(error_msg))
             self.manager.stream_is_crashing(self.stream_id, str(error_msg))
             self.manager.set_restart_request(self.stream_id)
             sys.exit(1)
         except IndexError as error_msg:
-            logging.error("BinanceWebSocketApiConnection.send(" + str(self.stream_id) + ", " +
+            logger.error("BinanceWebSocketApiConnection.send(" + str(self.stream_id) + ", " +
                           str(self.channels) + ", " + str(self.markets) + ") - Exception IndexError "
                           "- error_msg:  " + str(error_msg))
         except KeyError as error_msg:
-            logging.error("BinanceWebSocketApiConnection.send(" + str(self.stream_id) + ", " +
+            logger.error("BinanceWebSocketApiConnection.send(" + str(self.stream_id) + ", " +
                           str(self.channels) + ", " + str(self.markets) + ") - Exception KeyError "
                           "- error_msg:  " + str(error_msg))
         except ValueError as error_msg:
             # ValueError: The future belongs to a different loop than the one specified as the loop argument
-            logging.error(f"BinanceWebSocketApiConnection.send({str(self.stream_id)}) socket_id="
+            logger.error(f"BinanceWebSocketApiConnection.send({str(self.stream_id)}) socket_id="
                           f"{str(self.socket_id)}) - Closing this socket! - ValueError: {str(error_msg)}")
             self.manager.stream_is_stopping(self.stream_id)
             if self.manager.is_stop_request(self.stream_id) is False:

--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_restclient.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_restclient.py
@@ -40,6 +40,9 @@ import socket
 import threading
 import time
 
+logger = logging.getLogger(__name__)
+
+
 
 class BinanceWebSocketApiRestclient(object):
     def __init__(self, manager):
@@ -107,7 +110,7 @@ class BinanceWebSocketApiRestclient(object):
         :rtype: str or False
         """
         if action == "keepalive":
-            logging.info(f"BinanceWebSocketApiRestclient.keepalive_listen_key({str(self.listen_key_output)})")
+            logger.info(f"BinanceWebSocketApiRestclient.keepalive_listen_key({str(self.listen_key_output)})")
             method = "put"
             try:
                 response = self._request(method, self.path_userdata, False, {'listenKey': str(self.listen_key)})
@@ -118,18 +121,18 @@ class BinanceWebSocketApiRestclient(object):
             except TypeError:
                 return False
         elif action == "delete":
-            logging.info(f"BinanceWebSocketApiRestclient.delete_listen_key({str(self.listen_key_output)})")
+            logger.info(f"BinanceWebSocketApiRestclient.delete_listen_key({str(self.listen_key_output)})")
             method = "delete"
             try:
                 response = self._request(method, self.path_userdata, False, {'listenKey': str(self.listen_key)})
                 self.listen_key = False
                 return response
             except KeyError as error_msg:
-                logging.error(f"BinanceWebSocketApiRestclient.delete_listen_key({str(self.listen_key_output)}) - "
+                logger.error(f"BinanceWebSocketApiRestclient.delete_listen_key({str(self.listen_key_output)}) - "
                               f"KeyError - error_msg: {str(error_msg)}")
                 return False
             except TypeError as error_msg:
-                logging.error(f"BinanceWebSocketApiRestclient.delete_listen_key({str(self.listen_key_output)}) - "
+                logger.error(f"BinanceWebSocketApiRestclient.delete_listen_key({str(self.listen_key_output)}) - "
                               f"KeyError - error_msg: {str(error_msg)}")
                 return False
         else:
@@ -179,7 +182,7 @@ class BinanceWebSocketApiRestclient(object):
             if self.manager.show_secrets_in_logs is True:
                 self.listen_key_output = self.listen_key
         except KeyError as error_msg:
-            logging.error(f"BinanceWebSocketApiRestclient.init_vars() - TypeError - error_msg: {str(error_msg)}")
+            logger.error(f"BinanceWebSocketApiRestclient.init_vars() - TypeError - error_msg: {str(error_msg)}")
             return False
         return True
 
@@ -218,24 +221,24 @@ class BinanceWebSocketApiRestclient(object):
             else:
                 request_handler = False
         except requests.exceptions.ConnectionError as error_msg:
-            logging.critical(f"BinanceWebSocketApiRestclient._request() - error: 9 -  error_msg: {str(error_msg)}")
+            logger.critical(f"BinanceWebSocketApiRestclient._request() - error: 9 -  error_msg: {str(error_msg)}")
             return False
         except socket.gaierror as error_msg:
-            logging.critical(f"BinanceWebSocketApiRestclient._request() - error: 10 -  error_msg: {str(error_msg)}")
+            logger.critical(f"BinanceWebSocketApiRestclient._request() - error: 10 -  error_msg: {str(error_msg)}")
             return False
         if request_handler.status_code == "418":
-            logging.critical("BinanceWebSocketApiRestclient._request() - error_msg: received status_code 418 from binance! You got"
+            logger.critical("BinanceWebSocketApiRestclient._request() - error_msg: received status_code 418 from binance! You got"
                              "banned from the binance api! Read this: https://github.com/binance-exchange/binance-"
                              "official-api-sphinx/blob/master/rest-api.md#limits")
         elif request_handler.status_code == "429":
-            logging.critical("BinanceWebSocketApiRestclient._request() - error_msg: received status_code 429 from "
+            logger.critical("BinanceWebSocketApiRestclient._request() - error_msg: received status_code 429 from "
                              "binance! Back off or you are going to get banned! Read this: "
                              "https://github.com/binance-exchange/binance-official-api-sphinx/blob/master/"
                              "rest-api.md#limits")
         try:
             respond = request_handler.json()
         except json.decoder.JSONDecodeError as error_msg:
-            logging.error(f"BinanceWebSocketApiRestclient._request() - error_msg: {str(error_msg)}")
+            logger.error(f"BinanceWebSocketApiRestclient._request() - error_msg: {str(error_msg)}")
             return False
         self.manager.binance_api_status['weight'] = request_handler.headers.get('X-MBX-USED-WEIGHT')
         self.manager.binance_api_status['timestamp'] = time.time()
@@ -265,7 +268,7 @@ class BinanceWebSocketApiRestclient(object):
         :return: listen_key
         :rtype: str or False
         """
-        logging.info(f"BinanceWebSocketApiRestclient.get_listen_key() symbol='{str(self.symbol)}' "
+        logger.info(f"BinanceWebSocketApiRestclient.get_listen_key() symbol='{str(self.symbol)}' "
                      f"stream_id='{str(stream_id)}')")
         if stream_id is False:
             return False
@@ -279,7 +282,7 @@ class BinanceWebSocketApiRestclient(object):
             if self.manager.exchange == "binance.com-isolated_margin" or \
                     self.manager.exchange == "binance.com-isolated_margin-testnet":
                 if self.symbol is False:
-                    logging.critical("BinanceWebSocketApiRestclient.get_listen_key() - error_msg: Parameter "
+                    logger.critical("BinanceWebSocketApiRestclient.get_listen_key() - error_msg: Parameter "
                                      "`symbol` is missing!")
                     return False
                 else:
@@ -288,7 +291,7 @@ class BinanceWebSocketApiRestclient(object):
                 try:
                     response = self._request(method, self.path_userdata)
                 except AttributeError as error_msg:
-                    logging.critical(f"BinanceWebSocketApiRestclient.get_listen_key() - error: 8 - "
+                    logger.critical(f"BinanceWebSocketApiRestclient.get_listen_key() - error: 8 - "
                                      f"error_msg: {error_msg} - Can not acquire listen_key!")
                     return False
             try:
@@ -319,7 +322,7 @@ class BinanceWebSocketApiRestclient(object):
         :return: the response
         :rtype: str or False
         """
-        logging.info(f"BinanceWebSocketApiRestclient.delete_listen_key() stream_id='{str(stream_id)}')")
+        logger.info(f"BinanceWebSocketApiRestclient.delete_listen_key() stream_id='{str(stream_id)}')")
         if stream_id is False:
             return False
         with self.threading_lock:
@@ -348,7 +351,7 @@ class BinanceWebSocketApiRestclient(object):
         :return: the response
         :rtype: str or False
         """
-        logging.info(f"BinanceWebSocketApiRestclient.get_listen_key() stream_id='{str(stream_id)}')")
+        logger.info(f"BinanceWebSocketApiRestclient.get_listen_key() stream_id='{str(stream_id)}')")
         if stream_id is False:
             return False
         with self.threading_lock:

--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_restserver.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_restserver.py
@@ -36,6 +36,9 @@
 from flask_restful import Resource
 import logging
 
+logger = logging.getLogger(__name__)
+
+
 
 class BinanceWebSocketApiRestServer(Resource):
     """
@@ -67,10 +70,10 @@ class BinanceWebSocketApiRestServer(Resource):
         :rtype: list (status string, http status code)
         """
         if statusformat == "icinga":
-            logging.info(f"BinanceWebSocketApiRestServer.get({statusformat}, {str(checkcommandversion)}) - 200")
+            logger.info(f"BinanceWebSocketApiRestServer.get({statusformat}, {str(checkcommandversion)}) - 200")
             return self.manager.get_monitoring_status_icinga(check_command_version=checkcommandversion,
                                                              warn_on_update=self.warn_on_update), 200
         else:
-            logging.error(f"BinanceWebSocketApiRestServer.get({statusformat}, {str(checkcommandversion)}) - Service not"
+            logger.error(f"BinanceWebSocketApiRestServer.get({statusformat}, {str(checkcommandversion)}) - Service not"
                           f"found!")
             return "service not found", 404

--- a/unicorn_binance_websocket_api/unicorn_binance_websocket_api_socket.py
+++ b/unicorn_binance_websocket_api/unicorn_binance_websocket_api_socket.py
@@ -43,6 +43,9 @@ import time
 import uuid
 import websockets
 
+logger = logging.getLogger(__name__)
+
+
 
 class BinanceWebSocketApiSocket(object):
     def __init__(self, manager, stream_id, channels, markets):
@@ -58,7 +61,7 @@ class BinanceWebSocketApiSocket(object):
         self.exchange = manager.get_exchange()
 
     async def start_socket(self):
-        logging.info(f"BinanceWebSocketApiSocket.start_socket({str(self.stream_id)}, {str(self.channels)}, "
+        logger.info(f"BinanceWebSocketApiSocket.start_socket({str(self.stream_id)}, {str(self.channels)}, "
                      f"{str(self.markets)}) socket_id={str(self.socket_id)} recent_socket_id={str(self.socket_id)}")
         async with BinanceWebSocketApiConnection(self.manager,
                                                  self.stream_id,
@@ -76,7 +79,7 @@ class BinanceWebSocketApiSocket(object):
                     sys.exit(1)
                 try:
                     if self.manager.stream_list[self.stream_id]['recent_socket_id'] != self.socket_id:
-                        logging.error(f"BinanceWebSocketApiSocket.start_socket({str(self.stream_id)}, "
+                        logger.error(f"BinanceWebSocketApiSocket.start_socket({str(self.stream_id)}, "
                                       f"{str(self.channels)}, {str(self.markets)} socket_id={str(self.socket_id)} "
                                       f"recent_socket_id={str(self.socket_id)} - Sending payload - exit because its "
                                       f"not the recent socket id! stream_id={str(self.stream_id)}, recent_socket_id="
@@ -85,18 +88,18 @@ class BinanceWebSocketApiSocket(object):
                 except KeyError:
                     sys.exit(1)
                 while self.manager.stream_list[self.stream_id]['payload']:
-                    logging.info(f"BinanceWebSocketApiSocket.start_socket({str(self.stream_id)}, "
+                    logger.info(f"BinanceWebSocketApiSocket.start_socket({str(self.stream_id)}, "
                                  f"{str(self.channels)}, {str(self.markets)} socket_id={str(self.socket_id)} "
                                  f"recent_socket_id={str(self.socket_id)} - Sending payload started ...")
                     if self.manager.stream_list[self.stream_id]['recent_socket_id'] != self.socket_id:
-                        logging.error(f"BinanceWebSocketApiSocket.start_socket({str(self.stream_id)}, "
+                        logger.error(f"BinanceWebSocketApiSocket.start_socket({str(self.stream_id)}, "
                                       f"{str(self.channels)}, {str(self.markets)} socket_id={str(self.socket_id)} "
                                       f"recent_socket_id={str(self.socket_id)} - Sending payload - exit because its "
                                       f"not the recent socket id! stream_id={str(self.stream_id)}, recent_socket_id="
                                       f"{str(self.manager.stream_list[self.stream_id]['recent_socket_id'])}")
                         sys.exit(0)
                     payload = self.manager.stream_list[self.stream_id]['payload'].pop(0)
-                    logging.info(f"BinanceWebSocketApiSocket.start_socket({str(self.stream_id)}, "
+                    logger.info(f"BinanceWebSocketApiSocket.start_socket({str(self.stream_id)}, "
                                  f"{str(self.channels)}, {str(self.markets)} - Sending payload: {str(payload)}")
                     await websocket.send(json.dumps(payload, ensure_ascii=False))
                     # To avoid a ban we respect the limits of binance:
@@ -153,12 +156,12 @@ class BinanceWebSocketApiSocket(object):
                         self.manager.process_stream_data(received_stream_data,
                                                          stream_buffer_name=stream_buffer_name)
                         if "error" in received_stream_data_json:
-                            logging.error("BinanceWebSocketApiSocket.start_socket(" +
+                            logger.error("BinanceWebSocketApiSocket.start_socket(" +
                                           str(self.stream_id) + ") "
                                           "- Received error message: " + str(received_stream_data_json))
                             self.manager.add_to_ringbuffer_error(received_stream_data_json)
                         elif "result" in received_stream_data_json:
-                            logging.info("BinanceWebSocketApiSocket.start_socket(" +
+                            logger.info("BinanceWebSocketApiSocket.start_socket(" +
                                          str(self.stream_id) + ") "
                                          "- Received result message: " + str(received_stream_data_json))
                             self.manager.add_to_ringbuffer_result(received_stream_data_json)
@@ -170,7 +173,7 @@ class BinanceWebSocketApiSocket(object):
                             self.manager.stream_list[self.stream_id]['last_received_data_record'] = received_stream_data
 
                 except websockets.exceptions.ConnectionClosed as error_msg:
-                    logging.critical("BinanceWebSocketApiSocket.start_socket(" + str(self.stream_id) + ", " +
+                    logger.critical("BinanceWebSocketApiSocket.start_socket(" + str(self.stream_id) + ", " +
                                      str(self.channels) + ", " + str(self.markets) + ") - Exception ConnectionClosed "
                                      "- error_msg: " + str(error_msg))
                     if "WebSocket connection is closed: code = 1008" in str(error_msg):
@@ -187,7 +190,7 @@ class BinanceWebSocketApiSocket(object):
                         self.manager.set_restart_request(self.stream_id)
                         sys.exit(1)
                 except AttributeError as error_msg:
-                    logging.error("BinanceWebSocketApiSocket.start_socket(" + str(self.stream_id) + ", " +
+                    logger.error("BinanceWebSocketApiSocket.start_socket(" + str(self.stream_id) + ", " +
                                   str(self.channels) + ", " + str(self.markets) + ") - Exception AttributeError - "
                                   "error_msg: " + str(error_msg))
                     self.manager.stream_is_crashing(self.stream_id, str(error_msg))
@@ -195,7 +198,7 @@ class BinanceWebSocketApiSocket(object):
                     sys.exit(1)
 
                 except Exception as error_msg:
-                    logging.error("BinanceWebSocketApiSocket.start_socket(" + str(self.stream_id) + ", " +
+                    logger.error("BinanceWebSocketApiSocket.start_socket(" + str(self.stream_id) + ", " +
                                   str(self.channels) + ", " + str(self.markets) + ") - Exception General Exception - "
                                                                                   "error_msg: " + str(error_msg))
                     self.manager.stream_is_crashing(self.stream_id, str(error_msg))


### PR DESCRIPTION
# PR Details
Correctly scope loggers so that it plays nicely with others.

## Description
`logger = logging.getLogger(__name__)` then replace every call to the root logger with `logger`.

## Related Issue
#164 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Ran my code to consume websockets with `logging.getLogger("unicorn_binance_websocket_api.unicorn_binance_websocket_api_manager").setLevel(logging.WARNING)
` and got the level of chattiness I wanted.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the 
**[CONTRIBUTING](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/blob/master/CONTRIBUTING.md)** 
document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
