### PR TITLE
Update requirements: remove pathlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ cheroot
 colorama
 flask
 flask_restful
-pathlib
 psutil
 requests
 ujson


### PR DESCRIPTION
Removing the pathlib dependency; it might interfere with some other projects and it's no longer needed. Pathlib is included in python core >= 3.5, this project required at least 3.7