### PR TITLE
Fix: avoid scientific notation for float params in WsApi order methods (issue #397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 - Python 3.14 support (GIL build)
 - `stop_manager()` and `stop_manager_with_all_streams()` now accept a `delete_listen_key` parameter
+### Fixed
+- `api/spot.py` and `api/futures.py`: float parameters (`price`, `quantity`, `stop_price`, etc.) were
+  converted to string using `str()`, which produces scientific notation (e.g. `1.9e-07`) for very small
+  values. Binance rejects these with error -1100. Now using `format(Decimal(repr(value)), 'f')` which
+  always produces decimal notation. (issue #397)
   (default `True`). Set to `False` if multiple processes share the same `listen_key` and stopping
   one process should not invalidate it for the others. (issue #396)
 ### Changed

--- a/unicorn_binance_websocket_api/api/futures.py
+++ b/unicorn_binance_websocket_api/api/futures.py
@@ -38,6 +38,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+from decimal import Decimal
 from typing import Optional, Union, Literal
 import logging
 import threading
@@ -501,7 +502,7 @@ class BinanceWebSocketApiApiFutures(object):
                 order_type.upper() == "LIMIT_MAKER" or
                 order_type.upper() == "STOP_LOSS_LIMIT" or
                 order_type.upper() == "TAKE_PROFIT_LIMIT"):
-            params['price'] = str(price)
+            params['price'] = format(Decimal(repr(price)), 'f')
         if (order_type.upper() == "LIMIT" or
                 order_type.upper() == "STOP_LOSS_LIMIT" or
                 order_type.upper() == "TAKE_PROFIT_LIMIT"):
@@ -513,7 +514,7 @@ class BinanceWebSocketApiApiFutures(object):
         if price_protect is not None:
             params['priceProtect'] = "TRUE" if price_protect is True else "FALSE"
         if quantity is not None:
-            params['quantity'] = str(quantity)
+            params['quantity'] = format(Decimal(repr(quantity)), 'f')
         if recv_window is not None:
             params['recvWindow'] = str(recv_window)
         if reduce_only is not None:
@@ -521,7 +522,7 @@ class BinanceWebSocketApiApiFutures(object):
         if self_trade_prevention_mode is not None:
             params['selfTradePreventionMode'] = self_trade_prevention_mode
         if stop_price is not None:
-            params['stopPrice'] = str(stop_price)
+            params['stopPrice'] = format(Decimal(repr(stop_price)), 'f')
         if working_type is not None:
             params['workingType'] = working_type
 
@@ -2121,8 +2122,8 @@ class BinanceWebSocketApiApiFutures(object):
                 return False
 
         params = {"apiKey": self._manager.stream_list[stream_id]['api_key'],
-                  "price": str(price),
-                  "quantity": str(quantity),
+                  "price": format(Decimal(repr(price)), 'f'),
+                  "quantity": format(Decimal(repr(quantity)), 'f'),
                   "side": side.upper(),
                   "symbol": symbol.upper(),
                   "timestamp": self._manager.get_timestamp()}

--- a/unicorn_binance_websocket_api/api/spot.py
+++ b/unicorn_binance_websocket_api/api/spot.py
@@ -38,6 +38,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+from decimal import Decimal
 from typing import Optional, Union, Literal
 import logging
 import threading
@@ -398,7 +399,7 @@ class BinanceWebSocketApiApiSpot(object):
         if cancel_restrictions is not None:
             params['cancelRestrictions'] = cancel_restrictions
         if iceberg_qty is not None:
-            params['icebergQty'] = str(iceberg_qty)
+            params['icebergQty'] = format(Decimal(repr(iceberg_qty)), 'f')
         if new_client_order_id is not None:
             params['NewClientOrderId'] = new_client_order_id
         if new_order_resp_type is not None:
@@ -409,15 +410,15 @@ class BinanceWebSocketApiApiSpot(object):
                 order_type.upper() == "LIMIT_MAKER" or
                 order_type.upper() == "STOP_LOSS_LIMIT" or
                 order_type.upper() == "TAKE_PROFIT_LIMIT"):
-            params['price'] = str(price)
+            params['price'] = format(Decimal(repr(price)), 'f')
         if (order_type.upper() == "LIMIT" or
                 order_type.upper() == "STOP_LOSS_LIMIT" or
                 order_type.upper() == "TAKE_PROFIT_LIMIT"):
             params['timeInForce'] = time_in_force
         if quantity is not None:
-            params['quantity'] = str(quantity)
+            params['quantity'] = format(Decimal(repr(quantity)), 'f')
         if quote_order_qty is not None:
-            params['quoteOrderQty'] = str(quote_order_qty)
+            params['quoteOrderQty'] = format(Decimal(repr(quote_order_qty)), 'f')
             if quantity is not None:
                 logger.warning(f"BinanceWebSocketApiApiSpot.cancel_and_replace_order() - error_msg: By using the "
                                f"parameter `quoteOrderQty` the use of `quantity` is suppressed!")
@@ -427,7 +428,7 @@ class BinanceWebSocketApiApiSpot(object):
         if self_trade_prevention_mode is not None:
             params['selfTradePreventionMode'] = self_trade_prevention_mode
         if stop_price is not None:
-            params['stopPrice'] = str(stop_price)
+            params['stopPrice'] = format(Decimal(repr(stop_price)), 'f')
             if trailing_delta is not None:
                 logger.warning(f"BinanceWebSocketApiApiSpot.cancel_and_replace_order() - error_msg: By using the "
                                f"parameter `stopPrice` the use of `trailingDelta` is suppressed!")
@@ -1057,22 +1058,22 @@ class BinanceWebSocketApiApiSpot(object):
                   "type": order_type}
 
         if iceberg_qty is not None:
-            params['icebergQty'] = str(iceberg_qty)
+            params['icebergQty'] = format(Decimal(repr(iceberg_qty)), 'f')
         if new_order_resp_type is not None:
             params['newOrderRespType'] = new_order_resp_type
         if (order_type.upper() == "LIMIT" or
                 order_type.upper() == "LIMIT_MAKER" or
                 order_type.upper() == "STOP_LOSS_LIMIT" or
                 order_type.upper() == "TAKE_PROFIT_LIMIT"):
-            params['price'] = str(price)
+            params['price'] = format(Decimal(repr(price)), 'f')
         if (order_type.upper() == "LIMIT" or
                 order_type.upper() == "STOP_LOSS_LIMIT" or
                 order_type.upper() == "TAKE_PROFIT_LIMIT"):
             params['timeInForce'] = time_in_force
         if quantity is not None:
-            params['quantity'] = str(quantity)
+            params['quantity'] = format(Decimal(repr(quantity)), 'f')
         if quote_order_qty is not None:
-            params['quoteOrderQty'] = str(quote_order_qty)
+            params['quoteOrderQty'] = format(Decimal(repr(quote_order_qty)), 'f')
             if quantity is not None:
                 logger.warning(f"BinanceWebSocketApiApiSpot.create_order() - error_msg: By using the parameter "
                                f"`quoteOrderQty` the use of `quantity` is suppressed!")
@@ -1082,7 +1083,7 @@ class BinanceWebSocketApiApiSpot(object):
         if self_trade_prevention_mode is not None:
             params['selfTradePreventionMode'] = self_trade_prevention_mode
         if stop_price is not None:
-            params['stopPrice'] = str(stop_price)
+            params['stopPrice'] = format(Decimal(repr(stop_price)), 'f')
             if trailing_delta is not None:
                 logger.warning(f"BinanceWebSocketApiApiSpot.create_order() - error_msg: By using the parameter "
                                f"`stopPrice` the use of `trailingDelta` is suppressed!")

--- a/unittest_binance_websocket_api.py
+++ b/unittest_binance_websocket_api.py
@@ -394,6 +394,22 @@ class TestBinanceComManagerTest(unittest.TestCase):
     def test_is_exchange_type_cex(self):
         self.assertEqual(self.__class__.ubwa.is_exchange_type("cex"), True)
 
+    def test_float_to_str_no_scientific_notation(self):
+        print(f"test_float_to_str_no_scientific_notation():")
+        from decimal import Decimal
+        test_cases = [
+            (1.9e-07, '0.00000019'),
+            (1.9e-05, '0.000019'),
+            (1.9e-06, '0.0000019'),
+            (23416.1, '23416.1'),
+            (0.00001, '0.00001'),
+            (100.0, '100.0'),
+        ]
+        for value, expected in test_cases:
+            result = format(Decimal(repr(value)), 'f')
+            self.assertEqual(result, expected, f"Failed for {value!r}: got {result!r}, expected {expected!r}")
+            self.assertNotIn('e', result.lower(), f"Scientific notation found in {result!r} for input {value!r}")
+
     def test_stop_manager_delete_listen_key_false(self):
         print(f"test_stop_manager_delete_listen_key_false():")
         with BinanceWebSocketApiManager(exchange="binance.com-testnet", debug=True) as ubwa:


### PR DESCRIPTION
## Summary

Fixes #397.

`str(1.9e-07)` in Python produces `'1.9e-07'` (scientific notation). Binance rejects this with error `-1100: Illegal characters found in parameter 'price'`.

Replaced all `str(value)` calls on float parameters (`price`, `quantity`, `stop_price`, `iceberg_qty`, `quote_order_qty`) in `api/spot.py` and `api/futures.py` with `format(Decimal(repr(value)), 'f')`, which always produces decimal notation:

```python
str(1.9e-07)                       # '1.9e-07'   ❌ Binance rejects
format(Decimal(repr(1.9e-07)), 'f') # '0.00000019' ✓
```

## Test plan

- [ ] `test_float_to_str_no_scientific_notation` — verifies correct decimal output for a range of small/large values and asserts no `e` in the result
- [ ] CI green