### PR TITLE
Fix: !userData streams for Spot/Margin now use WS API subscription flow (issue #399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## 2.10.2.dev (development stage/unreleased/unstable)
 ### Changed
 - build_wheels.yml: Upgraded `cibuildwheel` from `v3.0.0` to `v3.4.1`
+- `!userData` streams on `binance.com`, `binance.com-testnet`, `binance.com-margin`,
+  `binance.com-margin-testnet`, `binance.com-isolated_margin` and
+  `binance.com-isolated_margin-testnet` now use the new WS API subscription flow
+  (`userDataStream.subscribe.signature`) instead of the legacy REST listenKey approach.
+  Binance removed the Spot/Margin listenKey REST endpoints (`POST /api/v3/userDataStream` etc.)
+  in February 2026. The public interface is unchanged:
+  `create_stream('arr', '!userData', api_key=..., api_secret=...)` continues to work as before.
+  Futures exchanges are unaffected and keep their existing listenKey flow. (issue #399)
+- `connection_settings.py`: Added `USERDATA_WS_API_EXCHANGES` constant; added WS API base URIs
+  for `binance.com-margin`, `binance.com-margin-testnet`, `binance.com-isolated_margin` and
+  `binance.com-isolated_margin-testnet`
 ### Removed
 - `simplejson` dependency — unused in UBWA code; `orjson` is the sole JSON library
 ### Fixed

--- a/unicorn_binance_websocket_api/connection_settings.py
+++ b/unicorn_binance_websocket_api/connection_settings.py
@@ -79,13 +79,25 @@ CEX_EXCHANGES = [
 CONNECTION_SETTINGS = {
     Exchanges.BINANCE: (1024, "wss://stream.binance.com:9443/", "wss://ws-api.binance.com/ws-api/v3"),
     Exchanges.BINANCE_TESTNET: (1024, "wss://testnet.binance.vision/", "wss://testnet.binance.vision/ws-api/v3"),
-    Exchanges.BINANCE_MARGIN: (1024, "wss://stream.binance.com:9443/", None),
-    Exchanges.BINANCE_MARGIN_TESTNET: (1024, "wss://testnet.binance.vision/", None),
-    Exchanges.BINANCE_ISOLATED_MARGIN: (1024, "wss://stream.binance.com:9443/", None),
-    Exchanges.BINANCE_ISOLATED_MARGIN_TESTNET: (1024, "wss://testnet.binance.vision/", None),
+    Exchanges.BINANCE_MARGIN: (1024, "wss://stream.binance.com:9443/", "wss://ws-api.binance.com/ws-api/v3"),
+    Exchanges.BINANCE_MARGIN_TESTNET: (1024, "wss://testnet.binance.vision/", "wss://testnet.binance.vision/ws-api/v3"),
+    Exchanges.BINANCE_ISOLATED_MARGIN: (1024, "wss://stream.binance.com:9443/", "wss://ws-api.binance.com/ws-api/v3"),
+    Exchanges.BINANCE_ISOLATED_MARGIN_TESTNET: (1024, "wss://testnet.binance.vision/", "wss://testnet.binance.vision/ws-api/v3"),
     Exchanges.BINANCE_FUTURES: (200, "wss://fstream.binance.com/", "wss://ws-fapi.binance.com/ws-fapi/v1"),
     Exchanges.BINANCE_FUTURES_TESTNET: (200, "wss://stream.binancefuture.com/", "wss://testnet.binancefuture.com/ws-fapi/v1"),
     Exchanges.BINANCE_COIN_FUTURES: (200, "wss://dstream.binance.com/", None),
     Exchanges.BINANCE_US: (1024, "wss://stream.binance.us:9443/", None),
     Exchanges.TRBINANCE: (1024, "wss://stream-cloud.trbinance.com/", None),
 }
+
+# Exchanges that use the new WS API userDataStream subscription flow (userDataStream.subscribe.signature)
+# instead of the legacy REST listenKey approach (POST /api/v3/userDataStream).
+# Binance deprecated and removed the listenKey REST endpoints for Spot and Margin in February 2026.
+USERDATA_WS_API_EXCHANGES = frozenset([
+    Exchanges.BINANCE,
+    Exchanges.BINANCE_TESTNET,
+    Exchanges.BINANCE_MARGIN,
+    Exchanges.BINANCE_MARGIN_TESTNET,
+    Exchanges.BINANCE_ISOLATED_MARGIN,
+    Exchanges.BINANCE_ISOLATED_MARGIN_TESTNET,
+])

--- a/unicorn_binance_websocket_api/manager.py
+++ b/unicorn_binance_websocket_api/manager.py
@@ -38,7 +38,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-from .connection_settings import CEX_EXCHANGES, CONNECTION_SETTINGS
+from .connection_settings import CEX_EXCHANGES, CONNECTION_SETTINGS, USERDATA_WS_API_EXCHANGES
 from .exceptions import *
 from .restclient import BinanceWebSocketApiRestclient
 from .sockets import BinanceWebSocketApiSocket
@@ -788,6 +788,8 @@ class BinanceWebSocketApiManager(threading.Thread):
                                            'processed_receives_statistic': {},
                                            'transfer_rate_per_second': {'bytes': {}, 'speed': 0},
                                            'websocket_uri': None,
+                                           'userData_type': None,
+                                           'userdata_subscribe_id': None,
                                            '3rd-party-future': None}
             logger.debug(f"BinanceWebSocketApiManager._add_stream_to_stream_list() - Leaving `stream_list_lock`!")
         logger.info("BinanceWebSocketApiManager._add_stream_to_stream_list(" +
@@ -839,7 +841,8 @@ class BinanceWebSocketApiManager(threading.Thread):
             self.asyncio_queue[stream_id] = asyncio.Queue()
             if (self.stream_list[stream_id]['api'] is False
                     and ("!userData" in self.stream_list[stream_id]['markets']
-                         or "!userData" in self.stream_list[stream_id]['channels'])):
+                         or "!userData" in self.stream_list[stream_id]['channels'])
+                    and self.exchange not in USERDATA_WS_API_EXCHANGES):
                 logger.debug(f"BinanceWebSocketApiManager._create_stream_thread({stream_id} - "
                              f"Adding `_ping_listen_key({stream_id})` to asyncio loop ...")
                 loop.create_task(self._ping_listen_key(stream_id=stream_id))
@@ -923,6 +926,35 @@ class BinanceWebSocketApiManager(threading.Thread):
         query_string = '&'.join(["{}={}".format(d[0], d[1]) for d in ordered_data])
         m = hmac.new(api_secret.encode('utf-8'), query_string.encode('utf-8'), hashlib.sha256)
         return m.hexdigest()
+
+    def _build_userdata_subscribe_payload(self, stream_id: str) -> dict:
+        """
+        Build a signed `userDataStream.subscribe.signature` payload for the WS API userData subscription flow.
+
+        Used for Spot and Margin exchanges after Binance removed the REST listenKey endpoints in February 2026.
+        The signature is generated fresh on every call so it is safe to use on reconnects.
+
+        :param stream_id: the stream_id whose api_key/api_secret are used for signing
+        :type stream_id: str
+        :return: dict ready to be serialised and sent over the WebSocket
+        :rtype: dict
+        """
+        api_key = self.stream_list[stream_id]['api_key']
+        api_secret = self.stream_list[stream_id]['api_secret']
+        timestamp = self.get_timestamp()
+        query_string = f"apiKey={api_key}&timestamp={timestamp}"
+        signature = hmac.new(api_secret.encode('utf-8'),
+                             query_string.encode('utf-8'),
+                             hashlib.sha256).hexdigest()
+        return {
+            "id": str(uuid.uuid4()),
+            "method": "userDataStream.subscribe.signature",
+            "params": {
+                "apiKey": api_key,
+                "timestamp": timestamp,
+                "signature": signature
+            }
+        }
 
     @staticmethod
     def order_params(data):
@@ -1775,6 +1807,25 @@ class BinanceWebSocketApiManager(threading.Thread):
         if len(channels) == 1 and len(markets) == 1:
             if "!userData" in channels or "!userData" in markets:
                 if stream_id is not None:
+                    # New WS API subscription flow: Binance removed the REST listenKey endpoints for
+                    # Spot and Margin in February 2026. Authentication now happens via a signed
+                    # userDataStream.subscribe.signature message sent over the WebSocket after connect.
+                    if self.exchange in USERDATA_WS_API_EXCHANGES:
+                        with self.stream_list_lock:
+                            logger.debug(f"BinanceWebSocketApiManager.create_websocket_uri() - "
+                                         f"`stream_list_lock` was entered!")
+                            self.stream_list[stream_id]['userData_type'] = 'ws_api_signature'
+                            subscriptions = self.get_number_of_subscriptions(stream_id)
+                            self.stream_list[stream_id]['subscriptions'] = subscriptions
+                            logger.debug(f"BinanceWebSocketApiManager.create_websocket_uri() - "
+                                         f"Leaving `stream_list_lock`!")
+                        logger.info(f"BinanceWebSocketApiManager.create_websocket_uri({str(channels)}, "
+                                    f"{str(markets)}, {str(symbols)}) - Using new WS API userData subscription "
+                                    f"flow for exchange='{self.exchange}', stream_id={stream_id}, "
+                                    f"result: {self.websocket_api_base_uri}")
+                        return self.websocket_api_base_uri
+
+                    # Legacy listenKey flow (Futures and other exchanges where REST listenKey still works)
                     if self.stream_list[stream_id]['provided_listen_key'] is not None:
                         response = {'listenKey': self.stream_list[stream_id]['provided_listen_key']}
                         self.stream_list[stream_id]['listen_key'] = str(response['listenKey'])

--- a/unicorn_binance_websocket_api/sockets.py
+++ b/unicorn_binance_websocket_api/sockets.py
@@ -89,6 +89,22 @@ class BinanceWebSocketApiSocket(object):
                                                      symbols=self.symbols) as self.websocket:
                 if self.websocket is None:
                     raise StreamIsRestarting(stream_id=self.stream_id, reason="websocket is None")
+
+                # New WS API userData subscription flow (Spot/Margin, Binance Feb 2026 change):
+                # Authenticate by sending a signed subscription message right after connect.
+                # This replaces the legacy listenKey approach and is re-sent on every reconnect.
+                if self.manager.stream_list[self.stream_id].get('userData_type') == 'ws_api_signature':
+                    subscribe_payload = self.manager._build_userdata_subscribe_payload(self.stream_id)
+                    with self.manager.stream_list_lock:
+                        self.manager.stream_list[self.stream_id]['userdata_subscribe_id'] = subscribe_payload['id']
+                    if self.manager.show_secrets_in_logs is True:
+                        logger.info(f"BinanceWebSocketApiSocket.start_socket({str(self.stream_id)}) - "
+                                    f"Sending userDataStream.subscribe.signature: {subscribe_payload}")
+                    else:
+                        logger.info(f"BinanceWebSocketApiSocket.start_socket({str(self.stream_id)}) - "
+                                    f"Sending userDataStream.subscribe.signature (id={subscribe_payload['id']})")
+                    await self.websocket.send(orjson.dumps(subscribe_payload).decode("utf-8"))
+
                 if self.manager.stream_list[self.stream_id]['status'] == "restarting":
                     self.manager.increase_reconnect_counter(self.stream_id)
                 self.manager.stream_list[self.stream_id]['status'] = "running"
@@ -128,6 +144,26 @@ class BinanceWebSocketApiSocket(object):
 
                         received_stream_data_json = await self.websocket.receive()
                         if received_stream_data_json is not None:
+                            # Filter the userDataStream.subscribe.signature acknowledgment so it does
+                            # not reach the user's callback/stream_buffer. On auth failure, crash the
+                            # stream with a meaningful error instead of silently dropping events.
+                            userdata_subscribe_id = self.manager.stream_list[self.stream_id].get('userdata_subscribe_id')
+                            if userdata_subscribe_id and userdata_subscribe_id in received_stream_data_json:
+                                ack = orjson.loads(received_stream_data_json)
+                                with self.manager.stream_list_lock:
+                                    self.manager.stream_list[self.stream_id]['userdata_subscribe_id'] = None
+                                if ack.get('status') == 200:
+                                    logger.info(f"BinanceWebSocketApiSocket.start_socket({str(self.stream_id)}) - "
+                                                f"userDataStream.subscribe.signature acknowledged successfully")
+                                else:
+                                    error = ack.get('error', {})
+                                    error_msg = (f"userDataStream.subscribe.signature failed: "
+                                                 f"code={error.get('code')} msg={error.get('msg')}")
+                                    logger.critical(f"BinanceWebSocketApiSocket.start_socket("
+                                                    f"{str(self.stream_id)}) - {error_msg}")
+                                    raise StreamIsCrashing(stream_id=self.stream_id, reason=error_msg)
+                                continue
+
                             if self.output == "UnicornFy":
                                 if self.manager.stream_list[self.stream_id]['api'] is False:
                                     if self.exchange == "binance.com":


### PR DESCRIPTION
## Summary

Binance removed the REST listenKey endpoints for Spot and Margin (`POST /api/v3/userDataStream` etc.) in February 2026. This caused all `!userData` streams on those exchanges to fail with a `410 Gone` error (issue #399).

The fix implements the new `userDataStream.subscribe.signature` WS API subscription flow:

- Instead of fetching a listenKey via REST and embedding it in the stream URI, UBWA now connects to `wss://ws-api.binance.com/ws-api/v3` and sends a signed subscription message immediately after the WebSocket connection is established
- The signature is HMAC-SHA256 over `apiKey=...&timestamp=...` — same signing approach as the existing `api=True` WS trading streams
- The subscription is re-sent automatically on every reconnect (fresh timestamp each time)
- Auth failures crash the stream with a clear error message instead of silently dropping events
- The REST keepalive loop (`_ping_listen_key`) is no longer started for these exchanges

**Exchanges using the new flow:** `binance.com`, `binance.com-testnet`, `binance.com-margin`, `binance.com-margin-testnet`, `binance.com-isolated_margin`, `binance.com-isolated_margin-testnet`

**Exchanges unaffected (keep existing listenKey flow):** `binance.com-futures`, `binance.com-coin_futures`, `binance.com-futures-testnet`

**Public interface is unchanged:**
```python
ubwa.create_stream('arr', '!userData', api_key='...', api_secret='...')
```

## Files changed

| File | Change |
|------|--------|
| `connection_settings.py` | Added `USERDATA_WS_API_EXCHANGES` constant; WS API URIs for margin/isolated_margin |
| `manager.py` | `create_websocket_uri()`: new flow branch; `_build_userdata_subscribe_payload()`: fresh signed payload; `_create_stream_thread()`: skip keepalive for new flow |
| `sockets.py` | Send subscription after connect; filter ack from stream buffer; crash on auth failure |
| `CHANGELOG.md` | Documented the change |

## Test plan

- [ ] Create a `!userData` stream on `binance.com` with valid api_key/api_secret — should connect and receive account events
- [ ] Verify no `BinanceRequestException: Invalid Response: 410 Gone` errors
- [ ] Force a reconnect — subscription message should be re-sent automatically
- [ ] Test with invalid api_key — stream should crash with a clear error instead of silently hanging
- [ ] Verify Futures `!userData` stream still works unchanged

Closes #399