### PR TITLE
Fix: correct GitHub API URL in get_latest_release_info() from LUCIT to oliver-zehentleitner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/readme.html#installation-and-upgrade)
 
 ## 2.10.2.dev (development stage/unreleased/unstable)
+### Fixed
+- `get_latest_release_info()`: corrected GitHub API URL from the old `LUCIT-Systems-and-Development`
+  organization to `oliver-zehentleitner`
 ### Changed
 - build_wheels.yml: Upgraded `cibuildwheel` from `v3.0.0` to `v3.4.1`
 ### Removed

--- a/unicorn_binance_websocket_api/manager.py
+++ b/unicorn_binance_websocket_api/manager.py
@@ -2340,7 +2340,7 @@ class BinanceWebSocketApiManager(threading.Thread):
         :return: dict or None
         """
         try:
-            respond = requests.get(f'https://api.github.com/repos/LUCIT-Systems-and-Development/'
+            respond = requests.get(f'https://api.github.com/repos/oliver-zehentleitner/'
                                    f'unicorn-binance-websocket-api/releases/latest')
             latest_release_info = respond.json()
             return latest_release_info


### PR DESCRIPTION
## Summary

`get_latest_release_info()` in `manager.py` was still calling the old `LUCIT-Systems-and-Development` GitHub organization URL to check for the latest release. This caused version update checks to fail silently.

## Fix

```
- https://api.github.com/repos/LUCIT-Systems-and-Development/unicorn-binance-websocket-api/releases/latest
+ https://api.github.com/repos/oliver-zehentleitner/unicorn-binance-websocket-api/releases/latest
```

## Test plan
- [ ] Verify `get_latest_release_info()` returns valid release data
- [ ] Verify `get_latest_version()` and update-check warnings work correctly