### PR TITLE
Fix: deadlock in create_websocket_uri() silently blocks !userData Spot/Margin streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 - `get_latest_release_info()`: corrected GitHub API URL from the old `LUCIT-Systems-and-Development`
   organization to `oliver-zehentleitner`
-- `create_websocket_uri()`: fixed deadlock on `!userData` streams for Spot/Margin exchanges —
-  `get_number_of_subscriptions()` was called while holding `stream_list_lock`, but that method
-  also tries to acquire the same lock (`threading.Lock`, not `RLock`), causing the stream thread
-  to block forever. Moved the call outside the lock block. (issue #413)
 ### Changed
 - build_wheels.yml: Upgraded `cibuildwheel` from `v3.0.0` to `v3.4.1`
 - `!userData` streams on `binance.com`, `binance.com-testnet`, `binance.com-margin`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 - `get_latest_release_info()`: corrected GitHub API URL from the old `LUCIT-Systems-and-Development`
   organization to `oliver-zehentleitner`
+- `create_websocket_uri()`: fixed deadlock on `!userData` streams for Spot/Margin exchanges —
+  `get_number_of_subscriptions()` was called while holding `stream_list_lock`, but that method
+  also tries to acquire the same lock (`threading.Lock`, not `RLock`), causing the stream thread
+  to block forever. Moved the call outside the lock block. (issue #413)
 ### Changed
 - build_wheels.yml: Upgraded `cibuildwheel` from `v3.0.0` to `v3.4.1`
 - `!userData` streams on `binance.com`, `binance.com-testnet`, `binance.com-margin`,

--- a/unicorn_binance_websocket_api/manager.py
+++ b/unicorn_binance_websocket_api/manager.py
@@ -1811,11 +1811,11 @@ class BinanceWebSocketApiManager(threading.Thread):
                     # Spot and Margin in February 2026. Authentication now happens via a signed
                     # userDataStream.subscribe.signature message sent over the WebSocket after connect.
                     if self.exchange in USERDATA_WS_API_EXCHANGES:
+                        subscriptions = self.get_number_of_subscriptions(stream_id)
                         with self.stream_list_lock:
                             logger.debug(f"BinanceWebSocketApiManager.create_websocket_uri() - "
                                          f"`stream_list_lock` was entered!")
                             self.stream_list[stream_id]['userData_type'] = 'ws_api_signature'
-                            subscriptions = self.get_number_of_subscriptions(stream_id)
                             self.stream_list[stream_id]['subscriptions'] = subscriptions
                             logger.debug(f"BinanceWebSocketApiManager.create_websocket_uri() - "
                                          f"Leaving `stream_list_lock`!")


### PR DESCRIPTION
## Summary

- `create_websocket_uri()` called `get_number_of_subscriptions()` while already holding `stream_list_lock`
- `get_number_of_subscriptions()` also acquires `stream_list_lock` internally
- `stream_list_lock` is a `threading.Lock` (not `RLock`) → stream thread blocked forever
- Stream status never reached `running`, no events were received, no error visible to the user

Fix: move `get_number_of_subscriptions()` call to before the `with stream_list_lock` block.

Introduced in #411 (the WS API userData subscription flow for Spot/Margin).

## Test plan

- [x] Live-tested: `create_stream('arr', '!userData', api_key=..., api_secret=...)` on `binance.com`
- [x] Stream reaches status `running`
- [x] `executionReport` and `outboundAccountPosition` events received correctly
- [ ] Run unit tests