### PR TITLE
Fix AttributeError in get_latest_version when GitHub API request fails

### DIFF
--- a/unicorn_binance_websocket_api/manager.py
+++ b/unicorn_binance_websocket_api/manager.py
@@ -2412,8 +2412,9 @@ class BinanceWebSocketApiManager(threading.Thread):
         :return: str or None
         """
         logger.debug(f"BinanceWebSocketApiManager.get_latest_version() - Started ...")
-        # Do a fresh request if status is None or last timestamp is older 1 hour
-        if self.last_update_check_github['status'].get('tag_name') is None or \
+        # Do a fresh request if status is not a dict, has no tag_name, or last timestamp is older 1 hour
+        if not isinstance(self.last_update_check_github['status'], dict) or \
+                self.last_update_check_github['status'].get('tag_name') is None or \
                 (self.last_update_check_github['timestamp'] + (60 * 60) < time.time()):
             self.last_update_check_github['status'] = self.get_latest_release_info()
         if (self.last_update_check_github['status'] is not None and


### PR DESCRIPTION
## Summary
- `get_latest_release_info()` returns `None` on failure
- `get_latest_version()` then calls `.get('tag_name')` on `None`, causing `AttributeError: 'NoneType' object has no attribute 'get'`
- Fix: check `isinstance(status, dict)` before calling `.get()`

Same bug as oliver-zehentleitner/unicorn-binance-rest-api#105.