### PR TITLE
Add European Options (Vanilla Options) exchange support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/readme.html#installation-and-upgrade)
 
 ## 2.11.0.dev (development stage/unreleased/unstable)
+### Added
+- Support for Binance European Options (Vanilla Options) WebSocket streams via `exchange="binance.com-vanilla-options"`
+- New exchange strings: `binance.com-vanilla-options`, `binance.com-vanilla-options-testnet`
+- Connection settings: `wss://fstream.binance.com/public/` (200 max streams per connection)
 
 ## 2.11.0
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 [Contributing](#contributing) | [Disclaimer](#disclaimer)
 
 A Python SDK to use the Binance Websocket API`s (com+testnet, com-margin+testnet, com-isolated_margin+testnet, 
-com-futures+testnet, com-coin_futures, us, tr) in a simple, fast, flexible, robust and 
+com-futures+testnet, com-coin_futures, com-vanilla-options+testnet, us, tr) in a simple, fast, flexible, robust and 
 fully-featured way. 
 
 Part of '[UNICORN Binance Suite](https://github.com/oliver-zehentleitner/unicorn-binance-suite)'.
@@ -302,6 +302,8 @@ provides an API to the Binance Websocket API`s of
 [Binance Futures](https://binance-docs.github.io/apidocs/futures/en/#websocket-market-streams) 
 ([+Testnet](https://testnet.binancefuture.com)), 
 [Binance COIN-M Futures](https://binance-docs.github.io/apidocs/delivery/en/#change-log),
+[Binance European Options](https://developers.binance.com/docs/derivatives/option/general-info)
+([+Testnet](https://testnet.binancefuture.com)),
 [Binance US](https://github.com/binance-us/binance-official-api-docs) and
 [Binance TR](https://www.trbinance.com/apidocs) and supports sending requests 
 to the [Binance Websocket API](https://developers.binance.com/docs/binance-trading-api/websocket_api) and the streaming 
@@ -340,6 +342,8 @@ Use the [UNICORN Binance REST API](https://github.com/oliver-zehentleitner/unico
 | [Binance USD-M Futures](https://www.binance.com)                   | `binance.com-futures`                 | ![yes](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-websocket-api/master/images/misc/ok-icon.png) | ![yes](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-websocket-api/master/images/misc/ok-icon.png) |
 | [Binance USD-M Futures Testnet](https://testnet.binancefuture.com) | `binance.com-futures-testnet`         | ![yes](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-websocket-api/master/images/misc/ok-icon.png) | ![yes](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-websocket-api/master/images/misc/ok-icon.png) |
 | [Binance Coin-M Futures](https://www.binance.com)                  | `binance.com-coin_futures`            | ![yes](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-websocket-api/master/images/misc/ok-icon.png) | ![no](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-websocket-api/master/images/misc/x-icon.png)   |
+| [Binance European Options](https://www.binance.com)                | `binance.com-vanilla-options`         | ![yes](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-websocket-api/master/images/misc/ok-icon.png) | ![no](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-websocket-api/master/images/misc/x-icon.png)   |
+| [Binance European Options Testnet](https://testnet.binancefuture.com) | `binance.com-vanilla-options-testnet` | ![yes](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-websocket-api/master/images/misc/ok-icon.png) | ![no](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-websocket-api/master/images/misc/x-icon.png)   |
 | [Binance US](https://www.binance.us)                               | `binance.us`                          | ![yes](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-websocket-api/master/images/misc/ok-icon.png) | ![no](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-websocket-api/master/images/misc/x-icon.png)   |
 | [Binance TR](https://www.trbinance.com)                            | `trbinance.com`                       | ![yes](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-websocket-api/master/images/misc/ok-icon.png) | ![no](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-websocket-api/master/images/misc/x-icon.png)   |
 

--- a/unicorn_binance_websocket_api/connection_settings.py
+++ b/unicorn_binance_websocket_api/connection_settings.py
@@ -55,6 +55,8 @@ class Exchanges(str, Enum):
     BINANCE_FUTURES = "binance.com-futures"
     BINANCE_COIN_FUTURES = "binance.com-coin_futures"
     BINANCE_FUTURES_TESTNET = "binance.com-futures-testnet"
+    BINANCE_VANILLA_OPTIONS = "binance.com-vanilla-options"
+    BINANCE_VANILLA_OPTIONS_TESTNET = "binance.com-vanilla-options-testnet"
     BINANCE_US = "binance.us"
     TRBINANCE = "trbinance.com"
 
@@ -69,6 +71,8 @@ CEX_EXCHANGES = [
     Exchanges.BINANCE_FUTURES,
     Exchanges.BINANCE_COIN_FUTURES,
     Exchanges.BINANCE_FUTURES_TESTNET,
+    Exchanges.BINANCE_VANILLA_OPTIONS,
+    Exchanges.BINANCE_VANILLA_OPTIONS_TESTNET,
     Exchanges.BINANCE_US,
     Exchanges.TRBINANCE,
 ]
@@ -86,6 +90,8 @@ CONNECTION_SETTINGS = {
     Exchanges.BINANCE_FUTURES: (200, "wss://fstream.binance.com/", "wss://ws-fapi.binance.com/ws-fapi/v1"),
     Exchanges.BINANCE_FUTURES_TESTNET: (200, "wss://stream.binancefuture.com/", "wss://testnet.binancefuture.com/ws-fapi/v1"),
     Exchanges.BINANCE_COIN_FUTURES: (200, "wss://dstream.binance.com/", None),
+    Exchanges.BINANCE_VANILLA_OPTIONS: (200, "wss://fstream.binance.com/public/", None),
+    Exchanges.BINANCE_VANILLA_OPTIONS_TESTNET: (200, "wss://fstream.binancefuture.com/public/", None),
     Exchanges.BINANCE_US: (1024, "wss://stream.binance.us:9443/", None),
     Exchanges.TRBINANCE: (1024, "wss://stream-cloud.trbinance.com/", None),
 }

--- a/unittest_binance_websocket_api.py
+++ b/unittest_binance_websocket_api.py
@@ -777,6 +777,35 @@ class TestApiLive(unittest.TestCase):
         time.sleep(1)
 
 
+class TestBinanceOptionsManager(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        print(f"\r\nTestBinanceOptionsManager:")
+        cls.ubwa = BinanceWebSocketApiManager(exchange="binance.com-vanilla-options",
+                                              disable_colorama=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.ubwa.stop_manager()
+
+    def test_exchange_string(self):
+        self.assertEqual(str(self.__class__.ubwa.get_exchange()), "binance.com-vanilla-options")
+
+    def test_is_exchange_type_cex(self):
+        self.assertTrue(self.__class__.ubwa.is_exchange_type("cex"))
+
+    def test_max_subscriptions(self):
+        self.assertEqual(self.__class__.ubwa.get_limit_of_subscriptions_per_stream(), 200)
+
+    def test_create_stream(self):
+        stream_id = self.__class__.ubwa.create_stream(
+            markets=['btc-260626-120000-c'], channels=["depth@500ms"],
+            stream_label="options_test")
+        self.assertTrue(bool(stream_id))
+        time.sleep(3)
+        self.__class__.ubwa.stop_stream(stream_id)
+
+
 if __name__ == '__main__':
     try:
         unittest.main()


### PR DESCRIPTION
## Summary
- New exchange strings: `binance.com-vanilla-options`, `binance.com-vanilla-options-testnet`
- Connection settings: `wss://fstream.binance.com/public/` (verified live), 200 max streams, no WS API
- Enum, CEX_EXCHANGES list, and CONNECTION_SETTINGS updated
- Options symbols with hyphens (e.g. `btc-260626-120000-c`) pass through cleanly — no changes needed in stream creation
- Part 2/4 of Vanilla Options depth cache integration (UBRA → **UBWA** → UBLDC → UBDCC)

## Test plan
- [x] 4 new tests pass: exchange string, CEX type, max subscriptions, stream creation
- [x] 53/57 total tests pass (4 pre-existing failures unrelated to this change)
- [x] WS URL verified live via prototype: subscribe ACK + depth data received