### PR TITLE
Switch Sphinx theme to python-docs-theme-ubs

### DIFF
--- a/dev/sphinx/install_sphinx.sh
+++ b/dev/sphinx/install_sphinx.sh
@@ -38,7 +38,7 @@
 # IN THE SOFTWARE.
 set -xeuo pipefail
 python3 -m pip install sphinx --upgrade
-python3 -m pip install python-docs-theme-lucit --upgrade
+python3 -m pip install python-docs-theme-ubs --upgrade
 python3 -m pip install rich --upgrade
 python3 -m pip install myst-parser --upgrade
 python3 -m pip install sphinx-markdown-tables --upgrade

--- a/dev/sphinx/source/conf.py
+++ b/dev/sphinx/source/conf.py
@@ -83,7 +83,7 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-html_theme = 'python_docs_theme_lucit'
+html_theme = 'python_docs_theme_ubs'
 html_context = {'github_user_name': 'oliver-zehentleitner',
                 'github_repo_name': 'unicorn-binance-websocket-api',
                 'project_name': project,


### PR DESCRIPTION
## Summary
- Switch Sphinx theme from `python-docs-theme-lucit` to `python-docs-theme-ubs`
- Update `conf.py` and `install_sphinx.sh`