### PR TITLE
Remove all LUCIT references from examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ For each example you will find a `README.md` and a `requirements.txt` to install
 file is to download and start, if an example does not work, we are happy about a 
 [patch](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/fork) or a message via 
 [GitHub Issue](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/new/choose) or 
-[our chat](https://www.lucit.tech/get-support.html).
+the [GitHub issues](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues).
 
 Old examples are stored in the 
 [archive](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/tree/master/examples/_archive).

--- a/examples/_archive/example_apache_kafka.py
+++ b/examples/_archive/example_apache_kafka.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -36,9 +36,6 @@
 # Info:
 # depends on: https://pypi.org/project/kafka-python/
 # must not be installed: https://pypi.org/project/kafka (https://github.com/dpkp/kafka-python/issues/1566)
-
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 
 from aiokafka import AIOKafkaProducer
 from aiokafka.helpers import create_ssl_context
@@ -101,9 +98,6 @@ if __name__ == "__main__":
     kafka = {"server": "rocket.srvs.cloudkafka.com:9094",
              "user": "pfyrfgiv",
              "pass": "JUTrtwrJFYdMsYbEZGoL0Zt5m1WElPzS"}
-
-    # To use this library you need a valid UNICORN Binance Suite License:
-    # https://shop.lucit.services
 
     ubwa = BinanceWebSocketApiManager(exchange=exchange)
 

--- a/examples/_archive/example_binance_coin_futures.py
+++ b/examples/_archive/example_binance_coin_futures.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -54,9 +54,6 @@ def print_stream_data_from_stream_buffer(binance_websocket_api_manager):
         if oldest_stream_data_from_stream_buffer is None:
             time.sleep(0.01)
 
-
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 
 # create instance of BinanceWebSocketApiManager for Binance.com Futures
 binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com-coin_futures")

--- a/examples/_archive/example_binance_futures.py
+++ b/examples/_archive/example_binance_futures.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -51,9 +51,6 @@ def print_stream_data_from_stream_buffer(binance_websocket_api_manager):
         if oldest_stream_data_from_stream_buffer is None:
             time.sleep(0.01)
 
-
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 
 # create instance of BinanceWebSocketApiManager for Binance.com Futures
 binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com-futures")

--- a/examples/_archive/example_binance_futures_1s.py
+++ b/examples/_archive/example_binance_futures_1s.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -52,8 +52,6 @@ def print_stream_data_from_stream_buffer(binance_websocket_api_manager):
             time.sleep(0.01)
 
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 # create instance of BinanceWebSocketApiManager for Binance.com Futures
 binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com-futures")
 

--- a/examples/_archive/example_binance_us.py
+++ b/examples/_archive/example_binance_us.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -51,9 +51,6 @@ logging.basicConfig(level=logging.INFO,
                     filename=os.path.basename(__file__) + '.log',
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
-
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 
 # create instance of BinanceWebSocketApiManager for Binance US
 binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.us")

--- a/examples/_archive/example_bookticker.py
+++ b/examples/_archive/example_bookticker.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -54,8 +54,6 @@ def print_stream_data_from_stream_buffer(binance_websocket_api_manager):
             print(oldest_stream_data_from_stream_buffer)
 
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 # create instance of BinanceWebSocketApiManager and provide the function for stream processing
 binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com-futures")
 

--- a/examples/_archive/example_ctrl-c.py
+++ b/examples/_archive/example_ctrl-c.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -54,8 +54,6 @@ def print_stream_data_from_stream_buffer(binance_websocket_api_manager):
 
 
 if __name__ == '__main__':
-    # To use this library you need a valid UNICORN Binance Suite License:
-    # https://shop.lucit.services
     binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com")
     worker_thread = threading.Thread(target=print_stream_data_from_stream_buffer, args=(binance_websocket_api_manager,))
     worker_thread.start()

--- a/examples/_archive/example_demo.py
+++ b/examples/_archive/example_demo.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -42,8 +42,6 @@ logging.basicConfig(level=logging.DEBUG,
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 ubwa = unicorn_binance_websocket_api.BinanceWebSocketApiManager()
 
 

--- a/examples/_archive/example_easy_migration_from_python-binance.py
+++ b/examples/_archive/example_easy_migration_from_python-binance.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -46,8 +46,6 @@ def order_status(msg):
     print("order_status: " + str(msg))
 
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 bwsm = BinanceWebSocketApiManager()
 
 book_ticker_id = bwsm.create_stream("bookTicker", 'bnbbusd', stream_buffer_name=True)

--- a/examples/_archive/example_interactive_mode.py
+++ b/examples/_archive/example_interactive_mode.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -83,8 +83,6 @@ markets = []
 try:
     binance_api_key = ""
     binance_api_secret = ""
-    # To use this library you need a valid UNICORN Binance Suite License:
-    # https://shop.lucit.services
     binance_rest_client = unicorn_binance_rest_api.BinanceRestApiManager(binance_api_key, binance_api_secret)
     binance_websocket_api_manager = BinanceWebSocketApiManager()
 except requests.exceptions.ConnectionError:

--- a/examples/_archive/example_kline_1m_with_unicorn_fy.py
+++ b/examples/_archive/example_kline_1m_with_unicorn_fy.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -42,8 +42,6 @@ logging.basicConfig(level=logging.INFO,
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 # create instance of BinanceWebSocketApiManager
 binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com", output_default="UnicornFy")
 

--- a/examples/_archive/example_logging.py
+++ b/examples/_archive/example_logging.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -41,8 +41,6 @@ logging.basicConfig(level=logging.DEBUG,
                     style="{")
 
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com")
 
 markets = ['bnbbtc', 'ethbtc', 'btcusdt', 'bchabcusdt', 'xrpusdt', 'rvnbtc', 'ltcusdt', 'adausdt', 'eosusdt',

--- a/examples/_archive/example_monitoring.py
+++ b/examples/_archive/example_monitoring.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -45,9 +45,6 @@ logging.basicConfig(level=logging.DEBUG,
                     filename=os.path.basename(__file__) + '.log',
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
-
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 
 
 def print_stream_data_from_stream_buffer(binance_websocket_api_manager):

--- a/examples/_archive/example_multi_stream.py
+++ b/examples/_archive/example_multi_stream.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -44,8 +44,6 @@ logging.basicConfig(level=logging.DEBUG,
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 # create instance of BinanceWebSocketApiManager and provide the function for stream processing
 binance_websocket_api_manager = BinanceWebSocketApiManager(BinanceWebSocketApiProcessStreams.process_stream_data)
 

--- a/examples/_archive/example_multiple_userdata_streams.py
+++ b/examples/_archive/example_multiple_userdata_streams.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -55,8 +55,6 @@ def print_stream_buffer_data(binance_websocket_api_manager, stream_id):
             print(oldest_stream_data_from_stream_buffer)
 
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 # create instances of BinanceWebSocketApiManager
 binance_com_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com")
 

--- a/examples/_archive/example_pandas_ta-lib.py
+++ b/examples/_archive/example_pandas_ta-lib.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -56,8 +56,6 @@ logging.basicConfig(level=logging.DEBUG,
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 ubwa = BinanceWebSocketApiManager(exchange="binance.com", output_default="UnicornFy")
 ubwa.create_stream('kline_1m', 'btcusdt')
 

--- a/examples/_archive/example_plotting_last_price.py
+++ b/examples/_archive/example_plotting_last_price.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -39,8 +39,6 @@ except ImportError:
     print("Please install `matplotlib`! https://pypi.org/project/matplotlib")
     exit(1)
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 binance_websocket_api_manager = ubwam.BinanceWebSocketApiManager()
 binance_websocket_api_manager.create_stream("trade", "btcusdt", output="UnicornFy")
 

--- a/examples/_archive/example_process_streams.py
+++ b/examples/_archive/example_process_streams.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a

--- a/examples/_archive/example_remove_streams_from_manager.py
+++ b/examples/_archive/example_remove_streams_from_manager.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -50,8 +50,6 @@ def callback_signals(signal_type=None, stream_id=None, data_record=None, error_m
     print(f"SIGNAL: {signal_type} - {stream_id} - {data_record} - {error_msg}")
 
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 with BinanceWebSocketApiManager(auto_data_cleanup_stopped_streams=True,
                                 exchange="binance.com",
                                 process_stream_signals=callback_signals) as ubwa:

--- a/examples/_archive/example_socks5_proxy.py
+++ b/examples/_archive/example_socks5_proxy.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -62,8 +62,6 @@ if __name__ == "__main__":
                         style="{")
 
     try:
-        # To use this library you need a valid UNICORN Binance Suite License:
-        # https://shop.lucit.services
         ubwa = BinanceWebSocketApiManager(exchange='binance.com',
                                           socks5_proxy_server=socks5_proxy,
                                           socks5_proxy_ssl_verification=socks5_ssl_verification)

--- a/examples/_archive/example_stream_buffer.py
+++ b/examples/_archive/example_stream_buffer.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -43,8 +43,6 @@ logging.basicConfig(level=logging.INFO,
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 # create instance of BinanceWebSocketApiManager
 binance_websocket_api_manager = BinanceWebSocketApiManager()
 

--- a/examples/_archive/example_stream_buffer_extended.py
+++ b/examples/_archive/example_stream_buffer_extended.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -43,8 +43,6 @@ logging.basicConfig(level=logging.DEBUG,
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 # create instance of BinanceWebSocketApiManager
 ubwa = BinanceWebSocketApiManager()
 

--- a/examples/_archive/example_stream_buffer_fifo-lifo.py
+++ b/examples/_archive/example_stream_buffer_fifo-lifo.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -42,8 +42,6 @@ logging.basicConfig(level=logging.INFO,
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 # create instance of BinanceWebSocketApiManager
 binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com", stream_buffer_maxlen=3)
 

--- a/examples/_archive/example_stream_everything.py
+++ b/examples/_archive/example_stream_everything.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -76,8 +76,6 @@ except requests.exceptions.ConnectionError:
     print("No internet connection?")
     sys.exit(1)
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 ubwa = unicorn_binance_websocket_api.BinanceWebSocketApiManager(debug=True)
 
 # start a worker process to move the received stream_data from the stream_buffer to a print function

--- a/examples/_archive/example_stream_management.py
+++ b/examples/_archive/example_stream_management.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -41,8 +41,6 @@ logging.basicConfig(level=logging.INFO,
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 # create instance of BinanceWebSocketApiManager and provide the function for stream processing
 binance_websocket_api_manager = BinanceWebSocketApiManager()
 

--- a/examples/_archive/example_stream_management_extended.py
+++ b/examples/_archive/example_stream_management_extended.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -44,8 +44,6 @@ logging.basicConfig(level=logging.DEBUG,
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 # create instance of BinanceWebSocketApiManager and provide the function for stream processing
 binance_websocket_api_manager = BinanceWebSocketApiManager(BinanceWebSocketApiProcessStreams.process_stream_data)
 

--- a/examples/_archive/example_stream_signals.py
+++ b/examples/_archive/example_stream_signals.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -42,8 +42,6 @@ logging.basicConfig(level=logging.INFO,
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 binance_websocket_api_manager = BinanceWebSocketApiManager(enable_stream_signal_buffer=True)
 
 

--- a/examples/_archive/example_stream_signals_callback.py
+++ b/examples/_archive/example_stream_signals_callback.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -46,8 +46,6 @@ def print_stream_signals(signal_type=None, stream_id=None, data_record=None, err
     print(f"callback: {signal_type} - {stream_id} - {data_record} - {error_msg}")
 
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 ubwa = BinanceWebSocketApiManager(enable_stream_signal_buffer=True,
                                   process_stream_signals=print_stream_signals)
 

--- a/examples/_archive/example_subscribe.py
+++ b/examples/_archive/example_subscribe.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -56,8 +56,6 @@ def print_stream_data_from_stream_buffer(binance_websocket_api_manager):
             pass
 
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com")
 
 # start a worker process to move the received stream_data from the stream_buffer to a print function

--- a/examples/_archive/example_ticker_and_miniticker.py
+++ b/examples/_archive/example_ticker_and_miniticker.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -45,8 +45,6 @@ logging.basicConfig(level=logging.DEBUG,
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 # create instance of BinanceWebSocketApiManager and provide the function for stream processing
 binance_websocket_api_manager = BinanceWebSocketApiManager(BinanceWebSocketApiProcessStreams.process_stream_data)
 # binance_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com")

--- a/examples/_archive/example_trade_stream.py
+++ b/examples/_archive/example_trade_stream.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -43,8 +43,6 @@ logging.basicConfig(level=logging.DEBUG,
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 # create instance of BinanceWebSocketApiManager and provide the function for stream processing
 binance_websocket_api_manager = BinanceWebSocketApiManager(BinanceWebSocketApiProcessStreams.process_stream_data)
 

--- a/examples/_archive/example_trbinance_com.py
+++ b/examples/_archive/example_trbinance_com.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -52,8 +52,6 @@ logging.basicConfig(level=logging.DEBUG,
                     format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                     style="{")
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 # create instance of BinanceWebSocketApiManager for TR Binance
 ubwa = BinanceWebSocketApiManager(exchange="trbinance.com")
 

--- a/examples/_archive/example_userdata_stream.py
+++ b/examples/_archive/example_userdata_stream.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -67,9 +67,6 @@ binance_us_api_secret = ""
 # configure api key and secret for binance.us
 binance_com_iso_api_key = binance_com_api_key
 binance_com_iso_api_secret = binance_com_api_secret
-
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 
 # create instances of BinanceWebSocketApiManager
 binance_com_websocket_api_manager = BinanceWebSocketApiManager(exchange="binance.com",

--- a/examples/_archive/example_userdata_stream_new_style.py
+++ b/examples/_archive/example_userdata_stream_new_style.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -59,8 +59,6 @@ def print_stream_data_from_stream_buffer(binance_websocket_api_manager):
 api_key = ""
 api_secret = ""
 
-# To use this library you need a valid UNICORN Binance Suite License:
-# https://shop.lucit.services
 # create instances of BinanceWebSocketApiManager
 ubwa_com = BinanceWebSocketApiManager(exchange="binance.com")
 

--- a/examples/_archive/example_websocket_api.py
+++ b/examples/_archive/example_websocket_api.py
@@ -11,7 +11,7 @@
 #
 # Author: Oliver Zehentleitner
 #
-# Copyright (c) 2019-2024, LUCIT Systems and Development (https://www.lucit.tech)
+# Copyright (c) 2019-2024, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -78,8 +78,6 @@ if __name__ == "__main__":
                         format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                         style="{")
 
-    # To use this library you need a valid UNICORN Binance Suite License:
-    # https://shop.lucit.services
     ubwa = BinanceWebSocketApiManager(exchange='binance.com')
     try:
         asyncio.run(binance_stream(ubwa))

--- a/examples/binance_futures_websocket_best_practice/README.md
+++ b/examples/binance_futures_websocket_best_practice/README.md
@@ -9,9 +9,6 @@ Before running the provided script, install the required Python packages:
 ```bash
 pip install -r requirements.txt
 ```
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
@@ -26,5 +23,4 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).
+For further assistance or to report issues, please [visit the GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).

--- a/examples/binance_websocket_apache_kafka/README.md
+++ b/examples/binance_websocket_apache_kafka/README.md
@@ -17,9 +17,6 @@ GitHub [1](https://github.com/dpkp/kafka-python/issues/2412#issuecomment-1806341
 pip install git+https://github.com/dpkp/kafka-python.git
 ```
 
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Graceful Shutdown:
 The script is designed to handle a graceful shutdown upon receiving a KeyboardInterrupt (e.g., Ctrl+C) or encountering 
@@ -29,5 +26,4 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).
+For further assistance or to report issues, please [visit the GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).

--- a/examples/binance_websocket_api_futures/README.md
+++ b/examples/binance_websocket_api_futures/README.md
@@ -16,9 +16,6 @@ BINANCE_API_KEY=12A34BCD5678EFG90HIJKLM12NOP3456QR789STUV0WXYZ
 BINANCE_API_SECRET=a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6
 ```
 
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Trading Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
@@ -33,5 +30,4 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).
+For further assistance or to report issues, please [visit the GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).

--- a/examples/binance_websocket_api_futures/binance_websocket_api_futures.py
+++ b/examples/binance_websocket_api_futures/binance_websocket_api_futures.py
@@ -84,8 +84,6 @@ if __name__ == "__main__":
                         style="{")
     load_dotenv()
 
-    # To use this library you need a valid UNICORN Binance Suite License:
-    # https://shop.lucit.services
     with BinanceWebSocketApiManager(exchange='binance.com-futures-testnet',
                                     output_default="dict",
                                     process_stream_signals=process_stream_signal) as ubwa_manager:

--- a/examples/binance_websocket_api_spot/README.md
+++ b/examples/binance_websocket_api_spot/README.md
@@ -16,9 +16,6 @@ BINANCE_API_KEY=12A34BCD5678EFG90HIJKLM12NOP3456QR789STUV0WXYZ
 BINANCE_API_SECRET=a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6
 ```
 
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Trading Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
@@ -33,5 +30,4 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).
+For further assistance or to report issues, please [visit the GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).

--- a/examples/binance_websocket_api_spot/binance_websocket_api_spot.py
+++ b/examples/binance_websocket_api_spot/binance_websocket_api_spot.py
@@ -99,8 +99,6 @@ if __name__ == "__main__":
     # Loading os.getenv() vars from .env
     load_dotenv()
 
-    # To use this library you need a valid UNICORN Binance Suite License:
-    # https://shop.lucit.services
     with BinanceWebSocketApiManager(exchange='binance.com',
                                     output_default="dict",
                                     process_stream_signals=process_stream_signal) as ubwa_manager:

--- a/examples/binance_websocket_best_practice/README.md
+++ b/examples/binance_websocket_best_practice/README.md
@@ -9,9 +9,6 @@ Before running the provided script, install the required Python packages:
 ```bash
 pip install -r requirements.txt
 ```
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
@@ -26,5 +23,4 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).
+For further assistance or to report issues, please [visit the GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).

--- a/examples/binance_websocket_kline_1m_ohlcv_to_sqlite/README.md
+++ b/examples/binance_websocket_kline_1m_ohlcv_to_sqlite/README.md
@@ -13,9 +13,6 @@ Before running the provided script, install the required Python packages:
 ```bash
 pip install -r requirements.txt
 ```
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Initialization:
 The script initializes a WebSocket connection to Binance using unicorn_binance_websocket_api and sets up an asynchronous 
@@ -45,5 +42,4 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).
+For further assistance or to report issues, please [visit the GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).

--- a/examples/binance_websocket_spot_userdata_async/README.md
+++ b/examples/binance_websocket_spot_userdata_async/README.md
@@ -10,9 +10,6 @@ Before running the provided script, install the required Python packages:
 ```bash
 pip install -r requirements.txt
 ```
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
@@ -27,5 +24,4 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).
+For further assistance or to report issues, please [visit the GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).

--- a/examples/binance_websocket_stream_signals/README.md
+++ b/examples/binance_websocket_stream_signals/README.md
@@ -19,9 +19,6 @@ Before running the provided script, install the required Python packages:
 ```bash
 pip install -r requirements.txt
 ```
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
@@ -36,5 +33,4 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).
+For further assistance or to report issues, please [visit the GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).

--- a/examples/binance_websocket_subscribe_unsubscribe/README.md
+++ b/examples/binance_websocket_subscribe_unsubscribe/README.md
@@ -9,9 +9,6 @@ Before running the provided script, install the required Python packages:
 ```bash
 pip install -r requirements.txt
 ```
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
@@ -26,5 +23,4 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).
+For further assistance or to report issues, please [visit the GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).

--- a/examples/ubwa-demo/README.md
+++ b/examples/ubwa-demo/README.md
@@ -1,6 +1,6 @@
 # UBWA Demo
 ## Overview
-This is the original script from https://ubwa-demo.lucit.tech
+This is the original demo script.
 
 ## Prerequisites
 Ensure you have Python 3.7+ installed on your system. 
@@ -16,9 +16,6 @@ BINANCE_API_KEY=12A34BCD5678EFG90HIJKLM12NOP3456QR789STUV0WXYZ
 BINANCE_API_SECRET=a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6
 ```
 
-## Get a UNICORN Binance Suite License
-To run modules of the *UNICORN Binance Suite* you need a [valid license](https://shop.lucit.services)!
-
 ## Usage
 ### Running the Script:
 ```bash
@@ -33,5 +30,4 @@ an unexpected exception.
 The script employs logging to provide insights into its operation and to assist in troubleshooting. Logs are saved to a 
 file named after the script with a .log extension.
 
-For further assistance or to report issues, please [contact our support team](https://www.lucit.tech/get-support.html) 
-or [visit our GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).
+For further assistance or to report issues, please [visit the GitHub repository](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api).

--- a/examples/ubwa-demo/ubwa-demo.py
+++ b/examples/ubwa-demo/ubwa-demo.py
@@ -19,7 +19,7 @@ load_dotenv()
 
 class BinanceDataProcessor:
     def __init__(self, ubwa_manager: BinanceWebSocketApiManager = None):
-        self.footer: str = "By LUCIT - www.lucit.tech"
+        self.footer: str = ""
         self.markets_limit = 10
         self.title: str = "UBWA Demo"
         self.ubwa: BinanceWebSocketApiManager = ubwa_manager


### PR DESCRIPTION
## Summary
- Delete license requirement sections (`shop.lucit.services` links) from all example READMEs
- Replace support team links (`lucit.tech`) with GitHub repository links
- Update copyright in `_archive/` from LUCIT to Oliver Zehentleitner
- Remove LUCIT footer from ubwa-demo
- 49 files cleaned

## Test plan
- [x] `grep -ri lucit examples/` returns zero matches