### PR TITLE
Fix MANIFEST.in so the sdist contains the api/ subpackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/readme.html#installation-and-upgrade)
 
 ## 2.12.0.dev (development stage/unreleased/unstable)
+### Fixed
+- `MANIFEST.in`: the previous pattern `include unicorn_binance_websocket_api/*.*`
+  only matched top-level files and excluded the `api/` subpackage, so the
+  source tarball on PyPI shipped `api/*.c` but no `api/*.py` or `api/*.pyi`.
+  Building from the sdist (e.g. conda-forge) therefore failed with
+  `ValueError: 'unicorn_binance_websocket_api/api/*.py' doesn't match any files`.
+  Switched to `recursive-include` so all Python, stub, Cython and binary
+  files in every subpackage are packaged.
 
 ## 2.12.0
 ### Added

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include unicorn_binance_websocket_api/*.*
+recursive-include unicorn_binance_websocket_api *.py *.pyi *.c *.pyx *.so *.dll *.pyd


### PR DESCRIPTION
## Problem
Building `unicorn-binance-websocket-api 2.12.0` from the PyPI sdist fails:

```
ValueError: 'unicorn_binance_websocket_api/api/*.py' doesn't match any files
```

Hit during the conda-forge 2.12.0 migration (feedstock PR #32 merged, but the main build failed and never published a package).

## Cause
`MANIFEST.in` used:
```
include unicorn_binance_websocket_api/*.*
```
which only matches top-level files. The `api/` subpackage therefore ended up in the sdist with only `.c` files (those are produced by Cython and picked up implicitly), but none of the `.py` / `.pyi` sources — the Extension glob in `setup.py` then has nothing to match.

## Fix
Switched to `recursive-include` covering `*.py`, `*.pyi`, `*.c`, `*.pyx`, `*.so`, `*.dll`, `*.pyd`. Also added a CHANGELOG entry.

## Release implications
Needs a 2.12.1 (or whatever version you pick) sdist respin on PyPI; the conda-forge recipe will then be bumped on top.