### PR TITLE
Bump minimum unicorn-binance-rest-api to 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 2.12.1.dev (development stage/unreleased/unstable)
 ### Changed
+- Bumped minimum `unicorn-binance-rest-api` dependency from `>=2.7.0`
+  to `>=2.11.0` in `setup.py`, `requirements.txt`, `pyproject.toml`,
+  `environment.yml` and `meta.yaml`. 2.11.0 is the cleanup-round
+  release.
 - `CONTRIBUTING.md` and `.github/pull_request_template.md`: removed the
   "submitted code becomes LUCIT IT-Management GmbH's property"
   clause and the LSOSL reference. Contributions are MIT-licensed now.

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.9
   - unicorn-fy>=0.15.0
-  - unicorn-binance-rest-api>=2.7.0
+  - unicorn-binance-rest-api>=2.11.0
   - colorama
   - Cython
   - orjson

--- a/meta.yaml
+++ b/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - requests >=2.31.0
     - typing_extensions
     - unicorn-fy >=0.15.0
-    - unicorn-binance-rest-api >=2.7.0
+    - unicorn-binance-rest-api >=2.11.0
     - websocket-client
     - websockets >=14.0
   run:
@@ -43,7 +43,7 @@ requirements:
     - requests >=2.31.0
     - typing_extensions
     - unicorn-fy >=0.15.0
-    - unicorn-binance-rest-api >=2.7.0
+    - unicorn-binance-rest-api >=2.11.0
     - websocket-client
     - websockets >=14.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ PySocks = "*"
 requests = ">=2.31.0"
 typing_extensions = "*"
 unicorn-fy = ">=0.15.0"
-unicorn-binance-rest-api = ">=2.7.0"
+unicorn-binance-rest-api = ">=2.11.0"
 websocket-client = "*"
 websockets = ">=14.0"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ PySocks
 requests>=2.31.0
 typing_extensions
 unicorn-fy>=0.15.0
-unicorn-binance-rest-api>=2.7.0
+unicorn-binance-rest-api>=2.11.0
 websocket-client
 websockets>=14.0

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     license='MIT',
     install_requires=['colorama', 'requests>=2.31.0', 'websocket-client', 'websockets>=14.0',
                       'orjson', 'psutil', 'PySocks',
-                      'unicorn-fy>=0.15.0', 'unicorn-binance-rest-api>=2.7.0', 'typing_extensions', 'Cython'],
+                      'unicorn-fy>=0.15.0', 'unicorn-binance-rest-api>=2.11.0', 'typing_extensions', 'Cython'],
     keywords='binance, asyncio, async, asynchronous, concurrent, websocket-api, webstream-api, '
              'binance-websocket, binance-webstream, webstream, websocket, api, binance-dex, '
              'binance-futures, binance-margin, binance-us',


### PR DESCRIPTION
2.11.0 is the cleanup-round UBRA release. Bumping the constraint across all five dependency files (setup.py as source of truth).