### PR TITLE
docs(README): add UBDCC deep-dive article to Related Articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ This is not a release version and can not be considered to be stable!
 - [Passing Binance Market Data to Apache Kafka in Python with aiokafka](https://blog.technopathy.club/passing-binance-market-data-to-apache-kafka-in-python-with-aiokafka)
 - [How to Connect to binance.com Websockets using Python via a Socks5 Proxy](https://blog.technopathy.club/binance-websocket-via-socks5)
 - [When IP Whitelisting Isn't What It Seems: A Real-World Case Study from the Binance API](https://blog.technopathy.club/when-ip-whitelisting-isn-t-what-it-seems-a-real-world-case-study-from-the-binance-api)
+- [UBDCC Deep Dive: Building a Trust Layer for Binance Order Books](https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books)
 - [UNICORN Binance Suite Article Series](https://blog.technopathy.club/series/unicorn-binance-suite)
 
 ## Project Homepage

--- a/llms.txt
+++ b/llms.txt
@@ -168,6 +168,10 @@ stream2 = ubwa.create_stream(channels="!userData", markets="arr",
 - [UBLDC](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache) — local order books built on UBWA. Use this instead of hand-rolling a depth-stream consumer.
 - [UnicornFy](https://github.com/oliver-zehentleitner/unicorn-fy) — normalize raw stream payloads into clean dicts; activate via `output_default="UnicornFy"`.
 
+## Related Articles
+
+- [UBDCC Deep Dive: Building a Trust Layer for Binance Order Books](https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books) — architecture of the multi-node UBDCC cluster built on top of UBWA streams; relevant when users ask how to scale beyond a single websocket consumer.
+
 ## Docs
 
 - Repo: https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api


### PR DESCRIPTION
## Summary
- Add link to the UBDCC deep-dive article in the *Related Articles* section.
- UBDCC is part of the UBWA-based stack — readers exploring the WebSocket API benefit from the higher-level trust-layer context.

## New link
- https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books

## Test plan
- [x] README renders correctly on GitHub
- [x] Link target is reachable