### PR TITLE
fix(futures): route via /public, /market, /private base paths (#437)

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -105,7 +105,7 @@ jobs:
           generate_release_notes: true
           name: unicorn-binance-websocket-api
           prerelease: false
-          tag_name: 2.12.2
+          tag_name: 2.13.0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create PyPi Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Open development tasks and decisions are tracked in **[TASKS.md](TASKS.md)**.
 
 Python SDK (MIT License) for connecting to Binance WebSocket streams. Enables multiplexed WebSocket connections, automatic buffering, reconnect handling, and WebSocket API calls (e.g. order placement).
 
-**Current Version:** 2.12.2  
+**Current Version:** 2.13.0  
 **Python Compatibility:** 3.9 – 3.14  
 **Author:** Oliver Zehentleitner  
 **PyPI:** `unicorn-binance-websocket-api`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,28 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
   [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/readme.html#installation-and-upgrade)
 
-## 2.12.2.dev (development stage/unreleased/unstable)
+## 2.13.0
+### Changed
+- USDT-M Futures (`BINANCE_FUTURES`, `BINANCE_FUTURES_TESTNET`):
+  WebSocket streams are now routed via the per-category base paths
+  `/public`, `/market` and `/private` introduced by Binance on
+  2026-04-23. Channels are auto-classified at connection time and
+  the matching path segment is prepended to `ws/` and
+  `stream?streams=`. The legacy `/ws` and `/stream` paths have been
+  decommissioned by Binance.
+  See [issue #437](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/437).
+### Added
+- `connection_settings.BINANCE_FUTURES_EXCHANGES` frozenset
+  containing the exchanges that route through the new per-category
+  Futures base paths.
+- `create_stream()` now raises `ValueError` on
+  `BINANCE_FUTURES`/`BINANCE_FUTURES_TESTNET` when
+  `channels`/`markets` resolve to more than one Futures category
+  (`public`/`market`/`private`). A single WebSocket connection can
+  no longer carry multiple categories; UBWA does not silently split
+  a stream into several connections — open one `create_stream()`
+  per category instead. Mirrors the existing `!userData`-in-
+  combined-stream rejection.
 
 ## 2.12.2
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
   [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/readme.html#installation-and-upgrade)
 
+## 2.12.2.dev (development stage/unreleased/unstable)
+
 ## 2.13.0
 ### Changed
 - USDT-M Futures (`BINANCE_FUTURES`, `BINANCE_FUTURES_TESTNET`):

--- a/README.md
+++ b/README.md
@@ -511,10 +511,10 @@ Run in bash:
 `pip install https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/archive/$(curl -s https://api.github.com/repos/oliver-zehentleitner/unicorn-binance-websocket-api/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")').tar.gz --upgrade`
 
 #### Windows
-Use the below command with the version (such as 2.12.2) you determined 
+Use the below command with the version (such as 2.13.0) you determined 
 [here](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/releases/latest):
 
-`pip install https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/archive/2.12.2.tar.gz --upgrade`
+`pip install https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/archive/2.13.0.tar.gz --upgrade`
 ### From the latest source (dev-stage) with PIP from [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api)
 This is not a release version and can not be considered to be stable!
 

--- a/dev/set_version_config.txt
+++ b/dev/set_version_config.txt
@@ -1,2 +1,2 @@
-2.12.2
+2.13.0
 meta.yaml,pyproject.toml,setup.py,README.md,.github/workflows/build_wheels.yml,dev/sphinx/source/conf.py,unicorn_binance_websocket_api/manager.py,AGENTS.md

--- a/dev/sphinx/source/conf.py
+++ b/dev/sphinx/source/conf.py
@@ -27,7 +27,7 @@ author = 'Oliver Zehentleitner'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '2.12.2'
+release = '2.13.0'
 
 html_last_updated_fmt = "%b %d %Y at %H:%M (CET)"
 

--- a/llms.txt
+++ b/llms.txt
@@ -5,7 +5,7 @@
 
 Beginner-friendly despite depth — complexity is optional, the API stays clean and Pythonic.
 
-Version: 2.12.2. Python 3.9 – 3.14.
+Version: 2.13.0. Python 3.9 – 3.14.
 
 ## Authorship & License
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unicorn-binance-websocket-api" %}
-{% set version = "2.12.2" %}
+{% set version = "2.13.0" %}
 
 package:
   name: {{ name|lower }}
@@ -568,10 +568,10 @@ about:
     `pip install https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/archive/$(curl -s https://api.github.com/repos/oliver-zehentleitner/unicorn-binance-websocket-api/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")').tar.gz --upgrade`
 
     #### Windows
-    Use the below command with the version (such as 2.12.2) you determined 
+    Use the below command with the version (such as 2.13.0) you determined 
     [here](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/releases/latest):
 
-    `pip install https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/archive/2.12.2.tar.gz --upgrade`
+    `pip install https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/archive/2.13.0.tar.gz --upgrade`
     ### From the latest source (dev-stage) with PIP from [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api)
     This is not a release version and can not be considered to be stable!
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unicorn-binance-websocket-api"
-version = "2.12.2"
+version = "2.13.0"
 description = "A Python SDK to use the Binance Websocket API`s (com+testnet, com-margin+testnet, com-isolated_margin+testnet, com-futures+testnet, com-coin_futures, us, tr, dex/chain+testnet) in a simple, fast, flexible, robust and fully-featured way."
 authors = ["Oliver Zehentleitner"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name=name,
-    version="2.12.2",
+    version="2.13.0",
     author="Oliver Zehentleitner",
     url="https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api",
     description="A Python SDK to use the Binance Websocket API`s (com+testnet, "

--- a/unicorn_binance_websocket_api/connection_settings.py
+++ b/unicorn_binance_websocket_api/connection_settings.py
@@ -107,3 +107,10 @@ USERDATA_WS_API_EXCHANGES = frozenset([
     Exchanges.BINANCE_ISOLATED_MARGIN,
     Exchanges.BINANCE_ISOLATED_MARGIN_TESTNET,
 ])
+
+# Exchanges that route USDT-M Futures WebSocket streams via the per-category base
+# paths /public, /market, /private (Binance announcement effective 2026-04-23).
+BINANCE_FUTURES_EXCHANGES = frozenset([
+    Exchanges.BINANCE_FUTURES,
+    Exchanges.BINANCE_FUTURES_TESTNET,
+])

--- a/unicorn_binance_websocket_api/manager.py
+++ b/unicorn_binance_websocket_api/manager.py
@@ -38,7 +38,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-from .connection_settings import CEX_EXCHANGES, CONNECTION_SETTINGS, USERDATA_WS_API_EXCHANGES
+from .connection_settings import (
+    BINANCE_FUTURES_EXCHANGES,
+    CEX_EXCHANGES,
+    CONNECTION_SETTINGS,
+    USERDATA_WS_API_EXCHANGES,
+)
 from .exceptions import *
 from .restclient import BinanceWebSocketApiRestclient
 from .sockets import BinanceWebSocketApiSocket
@@ -71,10 +76,70 @@ import orjson
 import websockets
 
 __app_name__: str = "unicorn-binance-websocket-api"
-__version__: str = "2.12.2.dev"
+__version__: str = "2.13.0.dev"
 __logger__: logging.getLogger = logging.getLogger("unicorn_binance_websocket_api")
 
 logger = __logger__
+
+
+# UBWA-internal channel/market suffix markers — they don't pin a Futures category.
+_FUTURES_SUFFIX_MARKERS = frozenset({"arr", "$all"})
+
+
+def _classify_futures_token(token: str) -> str:
+    """
+    Classify a single channel name or `!`-prefixed special market into one of the
+    Binance USDT-M Futures WebSocket categories: ``public``, ``market``, ``private``.
+
+    Per Binance announcement effective 2026-04-23, Futures streams are routed
+    via three distinct base paths:
+
+    * ``/public``  — bookTicker, depth (top-levels and diff)
+    * ``/market``  — aggTrade, kline, ticker, miniTicker, forceOrder, markPrice, ...
+    * ``/private`` — user data via listenKey
+    """
+    t = str(token).lower().lstrip("!").split("@", 1)[0]
+    if t == "bookticker":
+        return "public"
+    if t.startswith("depth"):
+        return "public"
+    if t == "userdata":
+        return "private"
+    return "market"
+
+
+def _resolve_futures_category(channels, markets) -> str:
+    """
+    Resolve the Futures WS category for a (channels, markets) combination.
+
+    Plain symbols (e.g. ``btcusdt``) and UBWA suffix markers (``arr``, ``$all``) do not
+    pin a category — only real channel names and ``!``-prefixed special markets do.
+
+    Raises ``ValueError`` when channels/markets resolve to more than one category.
+    Binance no longer permits multiple categories on a single WebSocket connection,
+    and UBWA does not silently split a stream into multiple connections — fail loud
+    so the caller opens one ``create_stream`` per category.
+    """
+    if isinstance(channels, str):
+        channels = [channels]
+    if isinstance(markets, str):
+        markets = [markets]
+    categories = set()
+    for ch in channels or []:
+        if str(ch).lower() in _FUTURES_SUFFIX_MARKERS:
+            continue
+        categories.add(_classify_futures_token(ch))
+    for mk in markets or []:
+        if str(mk).startswith("!"):
+            categories.add(_classify_futures_token(mk))
+    if len(categories) > 1:
+        raise ValueError(
+            f"BINANCE_FUTURES: mixing WebSocket categories on a single stream is not "
+            f"supported. Detected categories: {sorted(categories)}. "
+            f"Since 2026-04-23 Binance routes /public, /market, and /private separately "
+            f"for USDT-M Futures — open one create_stream() call per category."
+        )
+    return categories.pop() if categories else "market"
 
 
 class BinanceWebSocketApiManager(threading.Thread):
@@ -1682,6 +1747,12 @@ class BinanceWebSocketApiManager(threading.Thread):
             channels = [channels]
         if type(markets) is str:
             markets = [markets]
+        if api is False and self.exchange in BINANCE_FUTURES_EXCHANGES:
+            # Binance routes USDT-M Futures WS via /public, /market, /private since
+            # 2026-04-23 — a single connection cannot mix categories. Fail loud here
+            # before allocating a stream slot, instead of silently subscribing only
+            # part of the requested channels.
+            _resolve_futures_category(channels, markets)
         output = output or self.output_default
         close_timeout = close_timeout or self.close_timeout_default
         ping_interval = ping_interval or self.ping_interval_default
@@ -1766,6 +1837,16 @@ class BinanceWebSocketApiManager(threading.Thread):
                 else:
                     logger.error(f"BinanceWebSocketApiManager.create_stream({stream_id} - No valid asyncio loop!")
         return stream_id
+
+    def _futures_path_prefix(self, channels, markets) -> str:
+        """
+        Return the Futures category segment (``public/``, ``market/``, ``private/``)
+        to prepend before ``ws/`` or ``stream?streams=`` when building a Futures URI,
+        or empty string for any other exchange.
+        """
+        if self.exchange not in BINANCE_FUTURES_EXCHANGES:
+            return ""
+        return f"{_resolve_futures_category(channels, markets)}/"
 
     def create_websocket_uri(self, channels, markets, stream_id=None, symbols=None, api=False):
         """
@@ -1864,8 +1945,9 @@ class BinanceWebSocketApiManager(threading.Thread):
                         pass
                     if response:
                         try:
-                            uri = self.websocket_base_uri + "ws/" + str(response['listenKey'])
-                            uri_hidden = self.websocket_base_uri + "ws/" + self.replacement_text
+                            path_prefix = self._futures_path_prefix(channels, markets)
+                            uri = self.websocket_base_uri + path_prefix + "ws/" + str(response['listenKey'])
+                            uri_hidden = self.websocket_base_uri + path_prefix + "ws/" + self.replacement_text
                             if self.show_secrets_in_logs is True:
                                 logger.info("BinanceWebSocketApiManager.create_websocket_uri(" + str(channels) +
                                             ", " + str(markets) + ", " + str(symbols) + ") - result: " + uri)
@@ -1909,7 +1991,7 @@ class BinanceWebSocketApiManager(threading.Thread):
                         self.stream_list[stream_id]['subscriptions'] = subscriptions
                         logger.debug(f"BinanceWebSocketApiManager.create_websocket_uri() - Leaving "
                                      f"`stream_list_lock`")
-                return self.websocket_base_uri + "ws/!bookTicker"
+                return self.websocket_base_uri + self._futures_path_prefix(channels, markets) + "ws/!bookTicker"
             elif "arr" in channels or "$all" in markets:
                 if stream_id:
                     subscriptions = self.get_number_of_subscriptions(stream_id)
@@ -1919,7 +2001,7 @@ class BinanceWebSocketApiManager(threading.Thread):
                         self.stream_list[stream_id]['subscriptions'] = subscriptions
                         logger.debug(f"BinanceWebSocketApiManager.create_websocket_uri() - Leaving "
                                      f"`stream_list_lock`")
-                return self.websocket_base_uri + "ws/" + markets[0] + "@" + channels[0]
+                return self.websocket_base_uri + self._futures_path_prefix(channels, markets) + "ws/" + markets[0] + "@" + channels[0]
             elif "arr" in markets or "$all" in channels:
                 if stream_id:
                     subscriptions = self.get_number_of_subscriptions(stream_id)
@@ -1929,7 +2011,7 @@ class BinanceWebSocketApiManager(threading.Thread):
                         self.stream_list[stream_id]['subscriptions'] = subscriptions
                         logger.debug(f"BinanceWebSocketApiManager.create_websocket_uri() - Leaving "
                                      f"`stream_list_lock`")
-                return self.websocket_base_uri + "ws/" + channels[0] + "@" + markets[0]
+                return self.websocket_base_uri + self._futures_path_prefix(channels, markets) + "ws/" + channels[0] + "@" + markets[0]
         query = "stream?streams="
         final_market = "@arr"
         market = ""
@@ -1970,10 +2052,11 @@ class BinanceWebSocketApiManager(threading.Thread):
                 return None
         except KeyError:
             pass
+        path_prefix = self._futures_path_prefix(channels, markets)
         logger.info("BinanceWebSocketApiManager.create_websocket_uri(" + str(channels) + ", " +
                     str(markets) + ", " + ", " + str(symbols) + ") - Created websocket URI for stream_id=" +
-                    str(stream_id) + " is " + self.websocket_base_uri + str(query))
-        return self.websocket_base_uri + str(query)
+                    str(stream_id) + " is " + self.websocket_base_uri + path_prefix + str(query))
+        return self.websocket_base_uri + path_prefix + str(query)
 
     def delete_listen_key_by_stream_id(self, stream_id) -> bool:
         """


### PR DESCRIPTION
## Summary

Resolves #437 — Binance decommissioned the legacy `/ws` and `/stream` USDT-M Futures WebSocket paths on 2026-04-23 in favour of three per-category base paths: `/public`, `/market`, `/private`.

## What changed

- `connection_settings.py`: new `BINANCE_FUTURES_EXCHANGES` frozenset (mainnet + testnet).
- `manager.py`:
  - Module-level helpers `_classify_futures_token()` and `_resolve_futures_category()` map a channel/market token to its category.
  - Class method `_futures_path_prefix()` returns `public/`, `market/`, `private/` for Futures, empty string elsewhere.
  - `create_stream()` raises `ValueError` for `BINANCE_FUTURES`/`BINANCE_FUTURES_TESTNET` when channels/markets resolve to more than one category — fail loud instead of silently subscribing only part of the requested streams.
  - `create_websocket_uri()`: five URI-build sites prepend the prefix in front of `ws/` and `stream?streams=`.
- Mainnet and Testnet are treated identically per the open-question note in #437.
- `BINANCE_VANILLA_OPTIONS` (hardcoded `/public/` in its base URI) intentionally left untouched — separate cleanup.
- Version bumped to `2.13.0`.

## User-facing impact

- API unchanged — `create_stream(channels=..., markets=...)` works as before for any single-category combination.
- New behaviour: a stream that *would* require two Binance categories on one connection now raises `ValueError` with a message naming the detected categories and pointing the caller at separate `create_stream()` calls. Mirrors the existing `!userData`-in-combined-stream rejection pattern.
- Spot / Margin / Isolated Margin / COIN-M / BINANCE_US / TRBINANCE / WS-API: unaffected, mixing remains allowed where Binance still allows it.

## Test plan

Verified live against Binance:

- [x] Mainnet `/public/ws/btcusdt@bookTicker` — receives data
- [x] Mainnet `/market/stream?streams=btcusdt@aggTrade/ethusdt@aggTrade` combined — receives data, both symbols
- [x] Mainnet legacy `/stream?streams=...` — confirmed dead (connection ok, no messages)
- [x] Testnet `/public/ws/...` and `/market/ws/...` — receives data
- [x] Mixed-category `create_stream(["aggTrade","bookTicker"], ["btcusdt"])` → `ValueError("...categories: ['market', 'public']...")`
- [x] Spot regression: `create_stream(["aggTrade","bookTicker"], ["btcusdt"])` on `binance.com` still accepted
- [x] UserData listenKey REST roundtrip reaches Binance correctly (verified via auth response from a non-whitelisted IP); URI assembly to `/private/ws/<listenKey>` is trivial string concat once the helper resolves to `private`.