### PR TITLE
fix(setup): pin README.md read to UTF-8 (fixes Windows wheel build)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ for stub_file in os.listdir(os.path.join(stubs_dir, source_dir)):
 shutil.rmtree(os.path.join(stubs_dir))
 print("Stub files generated and moved successfully.")
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     print("Using README.md content as `long_description` ...")
     long_description = fh.read()
 


### PR DESCRIPTION
## Summary

`setup.py:73` opens `README.md` without an explicit encoding, so Python falls back to the platform default. On Linux/macOS that is UTF-8 (works), on Windows it is `cp1252` (breaks).

After commit \`2a3cb363\` "malware warning" added the ⚠️ emoji to README.md on 2026-04-22, the UTF-8 byte sequence \`e2 9a a0 ef b8 8f\` (U+26A0 + U+FE0F variation selector) lands in the file. The trailing \`0x8f\` is undefined in cp1252, so cibuildwheel on \`windows-2025\` crashes with:

\`\`\`
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 7: character maps to <undefined>
ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
\`\`\`

This broke the v2.13.0 release build (run [25153317045](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/actions/runs/25153317045)).

## Fix

One line — open README.md with `encoding="utf-8"`. The file is and has always been UTF-8.

## Test plan

- [x] Local sanity: `python3 -c "import setup"` parses cleanly (no behaviour change on Linux).
- [ ] Windows wheel build re-run after merge — that is the actual confirmation.

Note: the same issue likely lurks in any UBS-suite repo whose `setup.py` reads README.md without `encoding="utf-8"` — worth a quick suite-wide grep when you have time.