### PR TITLE
Changed listenKey parameter for userData stream. Extended the websocket URI with new get parameter - events

### DIFF
--- a/unicorn_binance_websocket_api/manager.py
+++ b/unicorn_binance_websocket_api/manager.py
@@ -1946,8 +1946,9 @@ class BinanceWebSocketApiManager(threading.Thread):
                     if response:
                         try:
                             path_prefix = self._futures_path_prefix(channels, markets)
-                            uri = self.websocket_base_uri + path_prefix + "ws/" + str(response['listenKey'])
-                            uri_hidden = self.websocket_base_uri + path_prefix + "ws/" + self.replacement_text
+                            events = "&events=ORDER_TRADE_UPDATE/ACCOUNT_UPDATE"
+                            uri = self.websocket_base_uri + path_prefix + "ws?listenKey=" + str(response['listenKey']) + events
+                            uri_hidden = self.websocket_base_uri + path_prefix + "ws?listenKey=" + self.replacement_text + events
                             if self.show_secrets_in_logs is True:
                                 logger.info("BinanceWebSocketApiManager.create_websocket_uri(" + str(channels) +
                                             ", " + str(markets) + ", " + str(symbols) + ") - result: " + uri)
@@ -2016,6 +2017,7 @@ class BinanceWebSocketApiManager(threading.Thread):
         final_market = "@arr"
         market = ""
         channel = ""
+        events = ""
         for market in markets:
             if "arr@" in market:
                 final_market = "@" + market


### PR DESCRIPTION
Contributions via GitHub pull requests are welcome. By submitting a pull request you agree that your
contribution is licensed under the project's
[MIT License](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/blob/master/LICENSE).

# PR Details

Refactored a listenKey parameter for userData stream. Now it passed as a query parameter, not as part of path, like it was before the breaking change from Binance @ 2026-04-23. 
Also added events query parameter to listen both ACCOUNT_UPDATE and ORDER_TRADE_UPDATE events.

## Description

Hotfix: A working version of the userData stream.

## Related Issue

#437 

## Motivation and Context

Testnet works for both old and new style websocket URI for userData streams.
But the prod version - not. It requires the changes provided.

## How Has This Been Tested

Tested on testnet - userData stream works.
Tested in production - userData stream works.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I agree that my contribution will be published under the
[MIT License](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/blob/master/LICENSE)
of this project.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the 
**[CONTRIBUTING](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/blob/master/CONTRIBUTING.md)** 
document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
