### PR TITLE
Configurable events filter for Futures userData streams (closes #445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
   [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/readme.html#installation-and-upgrade)
 
-## 2.13.1.dev (development stage/unreleased/unstable)
+## 2.14.0.dev (development stage/unreleased/unstable)
 ### Fixed
 - USDT-M Futures `!userData` streams (`BINANCE_FUTURES`,
   `BINANCE_FUTURES_TESTNET`): the `listenKey` is now passed as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   [@andykarpov](https://github.com/andykarpov) on
   [issue #437](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/437#issuecomment-4492250065)
   and originally fixed in [PR #445](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/pull/445).
+- `replace_stream()`: forwarded its arguments to `create_stream()`
+  positionally, but the 12th slot of `create_stream()` had become
+  `listen_key` (introduced with the WS API rework), so
+  `new_stream_buffer_maxlen` was silently bound to `listen_key`.
+  All arguments are now passed by keyword, eliminating the silent
+  parameter shift and future-proofing against signature additions.
 ### Added
 - `create_stream()` and `replace_stream()`: new optional `events` /
   `new_events` parameter selecting which event types Binance pushes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,36 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
   [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/readme.html#installation-and-upgrade)
 
-## 2.13.0.dev (development stage/unreleased/unstable)
+## 2.13.1.dev (development stage/unreleased/unstable)
+### Fixed
+- USDT-M Futures `!userData` streams (`BINANCE_FUTURES`,
+  `BINANCE_FUTURES_TESTNET`): the `listenKey` is now passed as a
+  query parameter (`/private/ws?listenKey=...`) instead of as a path
+  segment (`/private/ws/<listenKey>`). The path form has been
+  decommissioned by Binance on the mainnet `fstream` host; testnet
+  was still accepting both forms which masked the issue during the
+  2.13.0 verification round. Reported by
+  [@andykarpov](https://github.com/andykarpov) on
+  [issue #437](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/437#issuecomment-4492250065)
+  and originally fixed in [PR #445](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/pull/445).
+### Added
+- `create_stream()` and `replace_stream()`: new optional `events` /
+  `new_events` parameter selecting which event types Binance pushes
+  on a USDT-M Futures `!userData` stream
+  (`ORDER_TRADE_UPDATE`, `ACCOUNT_UPDATE`, `MARGIN_CALL`,
+  `TRADE_LITE`, `ACCOUNT_CONFIG_UPDATE`, `STRATEGY_UPDATE`,
+  `GRID_UPDATE`, `CONDITIONAL_ORDER_TRIGGER_REJECT`,
+  `ALGO_ORDER_UPDATE`, `listenKeyExpired`). Accepts a `str`, an
+  iterable of event names or `None`. `None` (the default) subscribes
+  to the full set, preserving the behaviour of the pre-2026-04-23
+  `/ws/<listenKey>` URL where every event arrived unfiltered. User-
+  supplied event names are not validated against an allow-list so
+  that Binance-side additions can be passed through immediately
+  without waiting for a UBWA release. Ignored for non-Futures
+  exchanges and non-userData streams.
+- `connection_settings.BINANCE_FUTURES_USERDATA_EVENTS` tuple
+  containing the default event subscription set, mirroring the
+  Binance docs for the USDⓈ-M Futures user data stream.
 
 ## 2.13.0
 ### Changed

--- a/examples/_archive/example_futures_userdata_events.py
+++ b/examples/_archive/example_futures_userdata_events.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# File: example_futures_userdata_events.py
+#
+# Part of 'UNICORN Binance WebSocket API'
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api
+# PyPI: https://pypi.org/project/unicorn-binance-websocket-api
+#
+# Author: Oliver Zehentleitner
+#
+# Copyright (c) 2019-2026, Oliver Zehentleitner
+# (https://about.me/oliver-zehentleitner)
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+"""
+USDT-M Futures user-data stream with explicit event-type filtering.
+
+Since 2026-04-23 the Binance USDⓈ-M Futures private WebSocket lives at
+`wss://fstream.binance.com/private/ws?listenKey=...&events=...` and requires
+an explicit `events` query parameter on production — without it the
+connection succeeds but no payloads arrive.
+
+UBWA subscribes to all documented event types by default (see
+`BINANCE_FUTURES_USERDATA_EVENTS` in `connection_settings.py`). This example
+shows the two common patterns:
+
+  1. Default — receive every event type.
+  2. Filter — restrict to a subset, e.g. order/account updates plus the
+     mandatory `listenKeyExpired` housekeeping event.
+
+For the authoritative list of event types, see:
+https://developers.binance.com/docs/derivatives/usds-margined-futures/user-data-streams
+"""
+
+from unicorn_binance_websocket_api.manager import BinanceWebSocketApiManager
+import logging
+import os
+import time
+
+
+logging.basicConfig(level=logging.INFO,
+                    filename=os.path.basename(__file__) + '.log',
+                    format="{asctime} [{levelname:8}] {process} {thread} "
+                           "{module}: {message}",
+                    style="{")
+
+
+API_KEY = os.getenv("BINANCE_FUTURES_API_KEY", "")
+API_SECRET = os.getenv("BINANCE_FUTURES_API_SECRET", "")
+
+
+def main():
+    with BinanceWebSocketApiManager(exchange="binance.com-futures") as ubwa:
+        # Pattern 1: default — subscribe to every documented event type.
+        full_stream_id = ubwa.create_stream(
+            channels=["arr"],
+            markets=["!userData"],
+            api_key=API_KEY,
+            api_secret=API_SECRET,
+            stream_label="futures-userdata-full",
+        )
+
+        # Pattern 2: filter — only the events this bot actually consumes.
+        # `listenKeyExpired` should be in any filtered set because UBWA's
+        # reconnect logic relies on it.
+        filtered_stream_id = ubwa.create_stream(
+            channels=["arr"],
+            markets=["!userData"],
+            api_key=API_KEY,
+            api_secret=API_SECRET,
+            events=["ORDER_TRADE_UPDATE", "ACCOUNT_UPDATE", "listenKeyExpired"],
+            stream_label="futures-userdata-filtered",
+        )
+
+        try:
+            while True:
+                record = ubwa.pop_stream_data_from_stream_buffer()
+                if record is None:
+                    time.sleep(0.01)
+                else:
+                    print(record)
+        except KeyboardInterrupt:
+            print("\nStopping ...")
+
+
+if __name__ == "__main__":
+    main()

--- a/unicorn_binance_websocket_api/connection_settings.py
+++ b/unicorn_binance_websocket_api/connection_settings.py
@@ -114,3 +114,28 @@ BINANCE_FUTURES_EXCHANGES = frozenset([
     Exchanges.BINANCE_FUTURES,
     Exchanges.BINANCE_FUTURES_TESTNET,
 ])
+
+# Default event subscription for the /private listenKey WebSocket on USDT-M Futures.
+# Since 2026-04-23 the private endpoint requires an explicit `&events=` filter — if
+# omitted, Binance production silently delivers nothing. To preserve the behaviour of
+# the previous `/ws/<listenKey>` URL (which streamed every event), UBWA subscribes to
+# all event types listed below by default. The user can override this with the
+# `events` parameter on `create_stream()` / `replace_stream()`.
+#
+# The list mirrors the event types documented at
+# https://developers.binance.com/docs/derivatives/usds-margined-futures/user-data-streams
+# as of UBWA's release date. UBWA does not validate user-supplied event names against
+# this list — Binance may add new events between releases and they can be passed
+# through immediately without waiting for a UBWA bump.
+BINANCE_FUTURES_USERDATA_EVENTS = (
+    "ORDER_TRADE_UPDATE",
+    "ACCOUNT_UPDATE",
+    "MARGIN_CALL",
+    "TRADE_LITE",
+    "ACCOUNT_CONFIG_UPDATE",
+    "STRATEGY_UPDATE",
+    "GRID_UPDATE",
+    "CONDITIONAL_ORDER_TRIGGER_REJECT",
+    "ALGO_ORDER_UPDATE",
+    "listenKeyExpired",
+)

--- a/unicorn_binance_websocket_api/manager.py
+++ b/unicorn_binance_websocket_api/manager.py
@@ -1946,8 +1946,9 @@ class BinanceWebSocketApiManager(threading.Thread):
                     if response:
                         try:
                             path_prefix = self._futures_path_prefix(channels, markets)
-                            uri = self.websocket_base_uri + path_prefix + "ws/" + str(response['listenKey'])
-                            uri_hidden = self.websocket_base_uri + path_prefix + "ws/" + self.replacement_text
+                            events = "&events=ORDER_TRADE_UPDATE/ACCOUNT_UPDATE"
+                            uri = self.websocket_base_uri + path_prefix + "ws?listenKey=" + str(response['listenKey']) + events
+                            uri_hidden = self.websocket_base_uri + path_prefix + "ws?listenKey=" + self.replacement_text + events
                             if self.show_secrets_in_logs is True:
                                 logger.info("BinanceWebSocketApiManager.create_websocket_uri(" + str(channels) +
                                             ", " + str(markets) + ", " + str(symbols) + ") - result: " + uri)
@@ -2016,6 +2017,7 @@ class BinanceWebSocketApiManager(threading.Thread):
         final_market = "@arr"
         market = ""
         channel = ""
+        events = ""
         for market in markets:
             if "arr@" in market:
                 final_market = "@" + market

--- a/unicorn_binance_websocket_api/manager.py
+++ b/unicorn_binance_websocket_api/manager.py
@@ -40,6 +40,7 @@
 
 from .connection_settings import (
     BINANCE_FUTURES_EXCHANGES,
+    BINANCE_FUTURES_USERDATA_EVENTS,
     CEX_EXCHANGES,
     CONNECTION_SETTINGS,
     USERDATA_WS_API_EXCHANGES,
@@ -53,7 +54,7 @@ from unicorn_fy.unicorn_fy import UnicornFy
 from collections import deque
 from datetime import datetime, timezone
 from operator import itemgetter
-from typing import Optional, Union, Callable, List, Set, Literal
+from typing import Optional, Union, Callable, Iterable, List, Set, Literal
 import asyncio
 import colorama
 import copy
@@ -717,6 +718,7 @@ class BinanceWebSocketApiManager(threading.Thread):
                                    keep_listen_key_alive=True,
                                    stream_buffer_maxlen=None,
                                    api=False,
+                                   events: Optional[tuple] = None,
                                    process_stream_data: Optional[Callable] = None,
                                    process_stream_data_async: Optional[Callable] = None,
                                    process_asyncio_queue: Optional[Callable] = None):
@@ -829,6 +831,7 @@ class BinanceWebSocketApiManager(threading.Thread):
                                            'close_timeout': copy.deepcopy(close_timeout),
                                            'provided_listen_key': copy.deepcopy(provided_listen_key),
                                            'keep_listen_key_alive': copy.deepcopy(keep_listen_key_alive),
+                                           'events': copy.deepcopy(events),
                                            'status': 'starting',
                                            'start_time': time.time(),
                                            'processed_receives_total': 0,
@@ -1603,6 +1606,7 @@ class BinanceWebSocketApiManager(threading.Thread):
                       keep_listen_key_alive: bool = True,
                       stream_buffer_maxlen: int = None,
                       api: bool = False,
+                      events: Union[str, Iterable[str], None] = None,
                       process_stream_data: Optional[Callable] = None,
                       process_stream_data_async: Optional[Callable] = None,
                       process_asyncio_queue: Optional[Callable] = None):
@@ -1705,6 +1709,32 @@ class BinanceWebSocketApiManager(threading.Thread):
                     Needs `api_key` and `api_secret` in combination. This type of stream can not be combined with a UserData
                     stream or another public endpoint. (Default is `False`)
         :type api: bool
+        :param events: Only applied to USDT-M Futures (`binance.com-futures`,
+                       `binance.com-futures-testnet`) `!userData` streams. Selects which event
+                       types Binance should push on the `/private/ws?listenKey=...&events=...`
+                       endpoint. Accepts a single event name as a string, an iterable of event
+                       names, or `None` (default).
+
+                       When `None` UBWA subscribes to all event types listed in
+                       `BINANCE_FUTURES_USERDATA_EVENTS
+                       <https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/blob/master/unicorn_binance_websocket_api/connection_settings.py>`__
+                       — preserves the behaviour of the pre-2026-04-23 `/ws/<listenKey>` URL
+                       that streamed every event.
+
+                       Known event types as of 2026-05: `ORDER_TRADE_UPDATE`, `ACCOUNT_UPDATE`,
+                       `MARGIN_CALL`, `TRADE_LITE`, `ACCOUNT_CONFIG_UPDATE`, `STRATEGY_UPDATE`,
+                       `GRID_UPDATE`, `CONDITIONAL_ORDER_TRIGGER_REJECT`, `ALGO_ORDER_UPDATE`,
+                       `listenKeyExpired`. The current authoritative list lives in the Binance
+                       `USDⓈ-M Futures user data streams docs
+                       <https://developers.binance.com/docs/derivatives/usds-margined-futures/user-data-streams>`__.
+
+                       UBWA does **not** validate the names against an allow-list — Binance may
+                       add new event types between UBWA releases and they can be passed through
+                       immediately without waiting for a UBWA bump. The trade-off is that typos
+                       in event names will silently produce a stream with no matching events.
+
+                       Ignored for non-Futures exchanges and for non-userData streams.
+        :type events: str, Iterable[str] or None
         :param process_stream_data: Provide a function/method to process the received webstream data (callback). The
                             function will be called instead of
                             `add_to_stream_buffer() <unicorn_binance_websocket_api.html#unicorn_binance_websocket_api.manager.BinanceWebSocketApiManager.add_to_stream_buffer>`__
@@ -1753,6 +1783,17 @@ class BinanceWebSocketApiManager(threading.Thread):
             # before allocating a stream slot, instead of silently subscribing only
             # part of the requested channels.
             _resolve_futures_category(channels, markets)
+        # Normalize `events` to a tuple. None → default set (all documented events).
+        # No validation against an allow-list — Binance may add events between UBWA
+        # releases, so unknown names are passed through as-is. Empty input also
+        # falls back to the default to avoid building a `&events=` query with no
+        # value (which Binance rejects on production).
+        if events is None:
+            events_tuple = BINANCE_FUTURES_USERDATA_EVENTS
+        elif isinstance(events, str):
+            events_tuple = (events,) if events else BINANCE_FUTURES_USERDATA_EVENTS
+        else:
+            events_tuple = tuple(str(e) for e in events) or BINANCE_FUTURES_USERDATA_EVENTS
         output = output or self.output_default
         close_timeout = close_timeout or self.close_timeout_default
         ping_interval = ping_interval or self.ping_interval_default
@@ -1790,6 +1831,7 @@ class BinanceWebSocketApiManager(threading.Thread):
                                         keep_listen_key_alive=keep_listen_key_alive,
                                         stream_buffer_maxlen=stream_buffer_maxlen,
                                         api=api,
+                                        events=events_tuple,
                                         process_stream_data=process_stream_data,
                                         process_stream_data_async=process_stream_data_async,
                                         process_asyncio_queue=process_asyncio_queue)
@@ -1946,9 +1988,22 @@ class BinanceWebSocketApiManager(threading.Thread):
                     if response:
                         try:
                             path_prefix = self._futures_path_prefix(channels, markets)
-                            events = "&events=ORDER_TRADE_UPDATE/ACCOUNT_UPDATE"
-                            uri = self.websocket_base_uri + path_prefix + "ws?listenKey=" + str(response['listenKey']) + events
-                            uri_hidden = self.websocket_base_uri + path_prefix + "ws?listenKey=" + self.replacement_text + events
+                            if self.exchange in BINANCE_FUTURES_EXCHANGES:
+                                # USDT-M Futures post-2026-04-23: listenKey is a query
+                                # parameter on /private/ws, and the events filter must
+                                # be supplied explicitly or Binance delivers nothing.
+                                events = self.stream_list[stream_id].get('events') \
+                                    or BINANCE_FUTURES_USERDATA_EVENTS
+                                events_qs = "&events=" + "/".join(events)
+                                uri = (self.websocket_base_uri + path_prefix
+                                       + "ws?listenKey=" + str(response['listenKey']) + events_qs)
+                                uri_hidden = (self.websocket_base_uri + path_prefix
+                                              + "ws?listenKey=" + self.replacement_text + events_qs)
+                            else:
+                                # Other exchanges where REST listenKey is still served
+                                # via the legacy /ws/<listenKey> path form.
+                                uri = self.websocket_base_uri + path_prefix + "ws/" + str(response['listenKey'])
+                                uri_hidden = self.websocket_base_uri + path_prefix + "ws/" + self.replacement_text
                             if self.show_secrets_in_logs is True:
                                 logger.info("BinanceWebSocketApiManager.create_websocket_uri(" + str(channels) +
                                             ", " + str(markets) + ", " + str(symbols) + ") - result: " + uri)
@@ -2017,7 +2072,6 @@ class BinanceWebSocketApiManager(threading.Thread):
         final_market = "@arr"
         market = ""
         channel = ""
-        events = ""
         for market in markets:
             if "arr@" in market:
                 final_market = "@" + market
@@ -3886,7 +3940,8 @@ class BinanceWebSocketApiManager(threading.Thread):
                        new_ping_interval=20,
                        new_ping_timeout=20,
                        new_close_timeout=10,
-                       new_stream_buffer_maxlen=None):
+                       new_stream_buffer_maxlen=None,
+                       new_events: Union[str, Iterable[str], None] = None):
         """
         Replace a stream
 
@@ -3942,6 +3997,10 @@ class BinanceWebSocketApiManager(threading.Thread):
                                      `stream_buffer`. The generic `stream_buffer` uses always the value of
                                      `BinanceWebSocketApiManager()`.
         :type new_stream_buffer_maxlen: int or None
+        :param new_events: USDT-M Futures `!userData` event filter — see the `events` parameter
+                           of `create_stream() <#unicorn_binance_websocket_api.manager.BinanceWebSocketApiManager.create_stream>`__
+                           for accepted values and behaviour.
+        :type new_events: str, Iterable[str] or None
         :return: stream_id or 'None'
         """
         # starting a new socket and stop the old stream not before the new stream received its first record
@@ -3956,7 +4015,8 @@ class BinanceWebSocketApiManager(threading.Thread):
                                            new_ping_interval,
                                            new_ping_timeout,
                                            new_close_timeout,
-                                           new_stream_buffer_maxlen)
+                                           new_stream_buffer_maxlen,
+                                           events=new_events)
         if self.wait_till_stream_has_started(new_stream_id):
             self.stop_stream(stream_id=stream_id, delete_listen_key=False)
         return new_stream_id

--- a/unicorn_binance_websocket_api/manager.py
+++ b/unicorn_binance_websocket_api/manager.py
@@ -4003,19 +4003,22 @@ class BinanceWebSocketApiManager(threading.Thread):
         :type new_events: str, Iterable[str] or None
         :return: stream_id or 'None'
         """
-        # starting a new socket and stop the old stream not before the new stream received its first record
-        new_stream_id = self.create_stream(new_channels,
-                                           new_markets,
-                                           new_stream_label,
-                                           new_stream_buffer_name,
-                                           new_api_key,
-                                           new_api_secret,
-                                           new_symbols,
-                                           new_output,
-                                           new_ping_interval,
-                                           new_ping_timeout,
-                                           new_close_timeout,
-                                           new_stream_buffer_maxlen,
+        # starting a new socket and stop the old stream not before the new stream received its first record.
+        # All arguments are passed by keyword so that future additions to `create_stream()` (and the
+        # 12th-positional `listen_key` introduced between the original `replace_stream()` design and the
+        # WS-API rework) cannot silently shift into the wrong parameter slot.
+        new_stream_id = self.create_stream(channels=new_channels,
+                                           markets=new_markets,
+                                           stream_label=new_stream_label,
+                                           stream_buffer_name=new_stream_buffer_name,
+                                           api_key=new_api_key,
+                                           api_secret=new_api_secret,
+                                           symbols=new_symbols,
+                                           output=new_output,
+                                           ping_interval=new_ping_interval,
+                                           ping_timeout=new_ping_timeout,
+                                           close_timeout=new_close_timeout,
+                                           stream_buffer_maxlen=new_stream_buffer_maxlen,
                                            events=new_events)
         if self.wait_till_stream_has_started(new_stream_id):
             self.stop_stream(stream_id=stream_id, delete_listen_key=False)


### PR DESCRIPTION
## Summary

Builds on @andykarpov's diagnosis and fix in #445 for the Binance USDT-M
Futures user-data WebSocket migration. Keeps his commit intact and adds
a configurable, default-all `events` filter on top, plus a drive-by
`replace_stream()` keyword-argument fix.

Two orthogonal things the old `/ws/<listenKey>` URL handled implicitly,
which the new `/private/ws?listenKey=...&events=...` URL no longer does:

1. `listenKey` must be a query parameter, not a path segment.
   Production fails silently if served as a path; testnet still
   tolerates the old form which masked this during 2.13.0 verification.
2. Without `&events=...` Binance production delivers no payloads.

#445 fixes (1) and hardcodes `&events=ORDER_TRADE_UPDATE/ACCOUNT_UPDATE`
to make (2) work. This PR keeps (1) and replaces the hardcoded two-event
list with a configurable filter that defaults to **all 10** documented
event types — so the new URL form matches the behaviour the old one had,
unfiltered by default.

## Changes

- `connection_settings.BINANCE_FUTURES_USERDATA_EVENTS` — tuple of the
  10 event types Binance currently documents for the USDⓈ-M Futures
  user-data stream. Single source of truth for the default subscription.
- `create_stream()` / `replace_stream()` — new optional `events` /
  `new_events` parameter (`str`, iterable of strings, or `None`).
  `None` → full default set; non-empty iterable → that exact subset.
- No allow-list validation. Names pass through to Binance verbatim so
  new event types can be used between UBWA releases without waiting
  for a bump. Trade-off: typos become silent no-ops, which is
  documented in the parameter docstring.
- `create_websocket_uri()` — builds `&events=...` from the per-stream
  list and gates the query-parameter URL on `BINANCE_FUTURES_EXCHANGES`.
  Non-Futures exchanges that still serve REST listenKey (COIN-M,
  BINANCE_US, TRBINANCE) keep the legacy `/ws/<listenKey>` path form.
  `events` are now also included in the result-URI INFO log line.
- Stray dead `events = ""` initializer in the combined-stream block
  removed; the only branch that ever referenced it was unreachable for
  `!userData` (rejected upstream).
- `examples/_archive/example_futures_userdata_events.py` — demonstrates
  the default and the filtered subscription patterns.
- `CHANGELOG.md` — 2.14.0.dev entry.

## Drive-by fix: `replace_stream()` silent parameter shift

`replace_stream()` forwarded arguments to `create_stream()` positionally.
Between its original design and the WS API rework `create_stream()`
gained a `listen_key` parameter at position 12 — which is exactly the
slot `replace_stream()` was using for `new_stream_buffer_maxlen`. Any
caller that supplied `new_stream_buffer_maxlen` was silently binding
that value to `listen_key`, while `stream_buffer_maxlen` itself fell
back to its default.

Switched all forwarded arguments to keyword form so future signature
additions cannot shift parameters again. Separate commit for review
clarity.

## Credits

Closes #445. @andykarpov's commit is preserved as the first commit of
this branch — the listenKey query-parameter fix and the original
two-event hotfix are his. The extension commit lists him as
`Co-Authored-By`.

## Test plan

- [x] Spot smoke test — verify existing exchanges still build legacy
      `/ws/<listenKey>` URLs (BINANCE_US, TRBINANCE, COIN-M).
- [x] BINANCE_FUTURES default — `create_stream(['arr'], ['!userData'])`
      produces `/private/ws?listenKey=K&events=<all 10 joined by />`.
- [x] BINANCE_FUTURES filtered — explicit `events=['ORDER_TRADE_UPDATE',
      'listenKeyExpired']` produces the expected joined query string.
- [x] `replace_stream(..., new_stream_buffer_maxlen=N)` — confirm `N`
      ends up in `stream_list[new_id]['stream_buffer_maxlen']`, not in
      `provided_listen_key`.
- [x] **Live verification on mainnet Futures (we cannot run this)** —
      asked @andykarpov in #445 to confirm that ACCOUNT_UPDATE and
      ORDER_TRADE_UPDATE arrive on his prod account against this branch.
- [x] Type check / unit tests pass.

