### PR TITLE
Add Keep the Why setup: context/, config block, badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+AGENTS.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,10 @@
 > **End-user cheatsheet for AI-assisted consumption:** [`llms.txt`](llms.txt) — use that one if you're writing code *against* this library.
 > **This file** is for AI agents working *on* this repo itself.
 
+## Why things are the way they are
+
+See [`context/index.md`](context/index.md) before making non-trivial changes — it points to the reasoning behind design decisions, rejected alternatives, and constraints that aren't visible in the code. If `AGENTS.local.md` exists in this repo, that's personal/local notes, not relevant to anyone else.
+
 ## Planning & Backlog
 
 Open development tasks and decisions are tracked in **[TASKS.md](TASKS.md)**.
@@ -28,7 +32,6 @@ unicorn_binance_websocket_api/     # Main package
     connection.py                  # Individual WebSocket connections (asyncio)
     sockets.py                     # Socket implementation with stream processing
     restclient.py                  # REST client for stream management
-    restserver.py                  # Flask REST server for external control
     connection_settings.py         # Exchanges enum + connection parameters
     exceptions.py                  # Custom exceptions
     api/                           # WebSocket API (trading) for Spot & Futures
@@ -60,12 +63,10 @@ Defined in `unicorn_binance_websocket_api/connection_settings.py` as the `Exchan
 Portfolio Margin (`binance.com-portfolio_margin`) is scoped to the user data
 stream lifecycle: `wss://fstream.binance.com/pm/ws/<listenKey>`, with the
 listenKey acquired/kept-alive/closed via UBRA's PAPI methods
-(`portfolio_margin_stream_get_listen_key()` etc.). It is intentionally NOT
-part of `BINANCE_FUTURES_EXCHANGES` — it keeps the legacy `/ws/<listenKey>`
-path form, not the `/private/ws?listenKey=...&events=...` form used by
-`binance.com-futures`/`binance.com-futures-testnet`. There is no
-`websocket_api_base_uri` (no WS API) and no public market-data endpoint for
-this exchange yet. See [issue #452](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/452).
+(`portfolio_margin_stream_get_listen_key()` etc.). Why it's scoped this way
+and deliberately not part of `BINANCE_FUTURES_EXCHANGES`:
+[`context/portfolio-margin.md`](context/portfolio-margin.md). See also
+[issue #452](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/452).
 
 ---
 
@@ -120,7 +121,8 @@ python setup.py bdist_wheel
 - `unit-tests.yml` — Python 3.8–3.13 on Ubuntu, Codecov upload
 - `build_wheels.yml` — Manual trigger, builds wheels for Linux/macOS/Windows, PyPI release
 - `codeql-analysis.yml` — Security scanning
-- `build_conda.yml` — Conda package build
+
+No in-repo conda build — conda-forge's own feedstock is the only conda source (same as the rest of the suite; see `context/history.md`).
 
 ---
 
@@ -143,7 +145,6 @@ python setup.py bdist_wheel
 | `BinanceWebSocketApiConnection` | `connection.py` | Individual WS connection (asyncio) |
 | `BinanceWebSocketApiSocket` | `sockets.py` | Stream processing |
 | `BinanceWebSocketApiRestclient` | `restclient.py` | REST client |
-| `BinanceWebSocketApiRestServer` | `restserver.py` | Flask REST server |
 | `WsApi` | `api/api.py` | Trading via WebSocket (Spot & Futures) |
 | `Exchanges` | `connection_settings.py` | Enum of all supported exchanges |
 
@@ -171,3 +172,8 @@ async def main():
     async with ubwa.get_stream_data_from_asyncio_queue(stream_id) as data:
         print(data)
 ```
+
+<!-- keep-the-why:config -->
+- context: `context/`
+- init: complete
+<!-- /keep-the-why:config -->

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 [![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
 [![Reddit](https://img.shields.io/badge/community-reddit-41ab8c)](https://www.reddit.com/r/UNICORNBinanceSuite)
+[![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
 
 [![UBS-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/logo/UBS-Banner-Readme.png)](https://blog.technopathy.club/page/unicorn-binance-suite)
 

--- a/context/README.md
+++ b/context/README.md
@@ -1,0 +1,10 @@
+<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why" width="200">
+
+# Context
+
+Why this project is built the way it is — architecture decisions,
+rejected alternatives, workarounds, and reasoning the code alone
+can't show. Captured and kept current by the [Keep the
+Why](https://keepthewhy.com) agent skill.
+
+Not usage docs — see `docs/` for that. Start with `index.md`.

--- a/context/history.md
+++ b/context/history.md
@@ -1,0 +1,34 @@
+# History
+
+## Repo origin: LUCIT-Systems-and-Development
+
+**Status:** superseded — repo now lives under `oliver-zehentleitner`
+**Confirmed** (git history; earliest commits reference `github.com/LUCIT-Systems-and-Development/unicorn-binance-websocket-api`)
+
+The repo was previously hosted under the `LUCIT-Systems-and-Development` GitHub org, with LUCIT branding, a LUCIT licensing/monitoring layer, and a contributor-copyright-assignment clause in `CONTRIBUTING.md`. It moved to `oliver-zehentleitner` and was cleaned up across many commits in 2026 (`remove LUCIT`, `Clean remaining LUCIT references outside the conda pipeline`, etc.) — same cleanup wave as the rest of the suite (see `unicorn-binance-suite`'s `context/history.md`).
+
+**Reason:** LUCIT is no longer part of how this project is licensed, distributed, or supported.
+
+**Also part of the same cleanup (commit `7f73d966`):** the in-repo `build_conda.yml` workflow was removed — conda-forge's own feedstock (`unicorn-binance-websocket-api-feedstock`) is the only conda build path now, same as the rest of the suite (see `unicorn-binance-suite`'s `context/packaging.md` for the fuller reasoning, which applies here too).
+
+## Icinga/monitoring REST server removed, not just rebranded
+
+**Status:** active
+**Confirmed** (commit `ee615105`)
+
+`restserver.py` (a Flask REST server exposing only a LUCIT/Icinga monitoring check-command endpoint) was deleted entirely — `start_monitoring_api()`, `stop_monitoring_api()`, `get_monitoring_status_icinga()`, and the related check-command methods are gone, along with the `flask`/`flask_restful`/`cheroot` dependencies. `get_monitoring_status_plain()` was kept, stripped of `check_lucit` references.
+
+**Reason:** this was LUCIT-specific monitoring-vendor integration (Icinga check commands), not a generic feature — removing it was part of decoupling from LUCIT, not a reduction in supported functionality for actual users of the library.
+
+**Stale docs caught while writing this:** `AGENTS.md`'s "Directory Structure" and "Key Classes" tables still listed `restserver.py` / `BinanceWebSocketApiRestServer` as if it still exists — it doesn't (verified: not present in `unicorn_binance_websocket_api/`). Fixed alongside this history entry. Don't confuse it with `restclient.py` (`BinanceWebSocketApiRestclient`), which is unrelated and still active — a REST client used for stream/listenKey management, not a REST server.
+
+## Hardcoded LUCIT org URL broke `get_latest_release_info()`
+
+**Status:** superseded — fixed
+**Confirmed** (commit `c2eb03ac`)
+
+After the repo moved from `LUCIT-Systems-and-Development` to `oliver-zehentleitner`, `get_latest_release_info()` still queried the GitHub API using the old org's URL, so the built-in "is an update available" check silently looked at the wrong (now-stale or gone) repo.
+
+**Reason it slipped through:** an org/repo rename doesn't fail loudly in a hardcoded API URL — the old endpoint may keep responding (redirect or stale data) rather than erroring, so nothing surfaced the mismatch until it was checked directly.
+
+**Revisit when:** the repo or org is renamed/moved again — grep for hardcoded `github.com/<org>/...` API URLs before assuming a rename is purely cosmetic.

--- a/context/index.md
+++ b/context/index.md
@@ -1,0 +1,4 @@
+# Context index
+
+- [portfolio-margin.md](portfolio-margin.md) — why `binance.com-portfolio_margin` is scoped to listenKey-only and kept outside `BINANCE_FUTURES_EXCHANGES`
+- [history.md](history.md) — the repo's LUCIT-Systems-and-Development origin, the Icinga/monitoring removal, and a stale-docs fix that came out of it

--- a/context/portfolio-margin.md
+++ b/context/portfolio-margin.md
@@ -1,0 +1,30 @@
+# Portfolio Margin exchange (`binance.com-portfolio_margin`)
+
+## Scoped to listenKey/user-data only, no market-data or WS API support
+
+**Status:** active
+**Confirmed** (issue [#452](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/452), commit `b53277f2`)
+
+`binance.com-portfolio_margin` only supports the user-data stream lifecycle (`wss://fstream.binance.com/pm/ws/<listenKey>`, listenKey acquired/kept-alive/closed via UBRA's PAPI methods). There is no `websocket_api_base_uri` (no WS API/order placement) and no public market-data endpoint for this exchange.
+
+**Reason:** Binance's Portfolio Margin API itself doesn't expose those surfaces (yet) — the scope here tracks what's actually available upstream, not an arbitrary internal limitation.
+
+## Deliberately outside `BINANCE_FUTURES_EXCHANGES`
+
+**Status:** active
+**Confirmed** (commit `b53277f2`: "deliberately outside BINANCE_FUTURES_EXCHANGES")
+
+**Rejected alternative:** folding `binance.com-portfolio_margin` into the existing `BINANCE_FUTURES_EXCHANGES` group, since it's futures-adjacent and could reuse that code path.
+
+**Reason it was rejected:** Portfolio Margin keeps the legacy `/ws/<listenKey>` URL form, while `binance.com-futures` / `binance.com-futures-testnet` already moved to the newer `/private/ws?listenKey=...&events=...` form. Grouping them would mean branching on exchange inside shared futures-path code for a URL-shape difference — kept as its own exchange entry instead so the routing stays a lookup, not a conditional.
+
+## Follow-up: graceful degradation for the not-yet-released dependency
+
+**Status:** active
+**Confirmed** (commit `f44ee416`, found during self-review of PR #453)
+
+`_init_ubra()` previously let UBRA's `UnknownExchange` exception propagate uncaught whenever the installed UBRA version didn't yet recognize `binance.com-portfolio_margin` (true for any UBRA release before PAPI support landed). That crashed the calling stream thread instead of degrading to `(None, None)`, which is what the surrounding `AttributeError` handling was already designed to produce. `get_listen_key()`, `keepalive_listen_key()`, and `delete_listen_key()` now check `_init_ubra()`'s return value and bail out cleanly instead.
+
+**Note:** this is a controlled degradation for a specific, known "dependency not released yet" condition on a single exchange's optional listenKey path — not a general precedent for swallowing errors. The suite's broader convention is to fail loud on broken invariants rather than silently continue; this case is about a well-defined missing-feature check, not a corrupted-data path.
+
+**Revisit when:** UBRA ships full Portfolio Margin support as a stable released version — at that point `UnknownExchange` for this exchange should no longer be reachable in practice, and the degradation path becomes dead code worth re-checking.


### PR DESCRIPTION
## Summary
- Adopts the Keep the Why convention: a `context/` directory documenting the reasoning behind the Portfolio Margin exchange design (`context/portfolio-margin.md`) and the repo's LUCIT-Systems-and-Development history (`context/history.md`)
- `AGENTS.md` trimmed: inline rationale replaced with pointers to `context/`
- Fixed two stale `AGENTS.md` entries found along the way: `restserver.py`/`BinanceWebSocketApiRestServer` and `build_conda.yml` no longer exist (removed during the Icinga/LUCIT cleanup, docs never caught up)
- `README.md`: Keep the Why badge added (last in the badge row)
- `.gitignore`: `AGENTS.local.md` (personal config, not committed)

## Test plan
- [ ] Read through `context/*.md` for accuracy against actual history
- [ ] Confirm the `restserver.py`/`build_conda.yml` removals are correctly reflected elsewhere (nothing else still references them)