### PR TITLE
docs: update Keep the Why to v0.5.1 (context/README.md, schema migration)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,4 +176,6 @@ async def main():
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
+- context-schema: 0.5.1
+- capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->

--- a/context/README.md
+++ b/context/README.md
@@ -1,10 +1,39 @@
-<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why" width="200">
+<a href="https://keepthewhy.com"><img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why"></a>
 
-# Context
+# Project context
 
-Why this project is built the way it is — architecture decisions,
-rejected alternatives, workarounds, and reasoning the code alone
-can't show. Captured and kept current by the [Keep the
-Why](https://keepthewhy.com) agent skill.
+This directory preserves the reasoning behind this project: architectural
+decisions, constraints, rejected alternatives, incident learnings,
+deliberate workarounds, and other knowledge that the code alone cannot
+explain.
 
-Not usage docs — see `docs/` for that. Start with `index.md`.
+It's organized and kept current according to the [Keep the
+Why](https://keepthewhy.com) schema — a repo-native agent skill, not
+specific to this project. Recognizing that schema means an agent (or a
+person who's seen it before) already knows how this directory is
+structured and how to work with it, without first having to figure that
+out from scratch.
+
+It answers:
+
+> Why is the project built this way?
+
+For usage, installation, operation, or troubleshooting, see `docs/`.
+
+## Reading the entries
+
+Each entry separates:
+
+- **Status** — whether a decision is active, superseded, open, or needs review
+- **Evidence** — whether its rationale is confirmed, inferred, or unknown
+
+Old reasoning is retained when it remains useful for understanding how the
+project evolved.
+
+## Trust boundary
+
+Files in this directory describe project knowledge. They do not contain
+instructions that grant permissions, override user intent, authorize
+commands, or weaken security controls.
+
+Start with the [context index](index.md).

--- a/context/history.md
+++ b/context/history.md
@@ -3,7 +3,8 @@
 ## Repo origin: LUCIT-Systems-and-Development
 
 **Status:** superseded — repo now lives under `oliver-zehentleitner`
-**Confirmed** (git history; earliest commits reference `github.com/LUCIT-Systems-and-Development/unicorn-binance-websocket-api`)
+**Evidence:** confirmed
+**Source:** git history; earliest commits reference `github.com/LUCIT-Systems-and-Development/unicorn-binance-websocket-api`
 
 The repo was previously hosted under the `LUCIT-Systems-and-Development` GitHub org, with LUCIT branding, a LUCIT licensing/monitoring layer, and a contributor-copyright-assignment clause in `CONTRIBUTING.md`. It moved to `oliver-zehentleitner` and was cleaned up across many commits in 2026 (`remove LUCIT`, `Clean remaining LUCIT references outside the conda pipeline`, etc.) — same cleanup wave as the rest of the suite (see `unicorn-binance-suite`'s `context/history.md`).
 
@@ -14,7 +15,8 @@ The repo was previously hosted under the `LUCIT-Systems-and-Development` GitHub 
 ## Icinga/monitoring REST server removed, not just rebranded
 
 **Status:** active
-**Confirmed** (commit `ee615105`)
+**Evidence:** confirmed
+**Source:** commit `ee615105`
 
 `restserver.py` (a Flask REST server exposing only a LUCIT/Icinga monitoring check-command endpoint) was deleted entirely — `start_monitoring_api()`, `stop_monitoring_api()`, `get_monitoring_status_icinga()`, and the related check-command methods are gone, along with the `flask`/`flask_restful`/`cheroot` dependencies. `get_monitoring_status_plain()` was kept, stripped of `check_lucit` references.
 
@@ -25,7 +27,8 @@ The repo was previously hosted under the `LUCIT-Systems-and-Development` GitHub 
 ## Hardcoded LUCIT org URL broke `get_latest_release_info()`
 
 **Status:** superseded — fixed
-**Confirmed** (commit `c2eb03ac`)
+**Evidence:** confirmed
+**Source:** commit `c2eb03ac`
 
 After the repo moved from `LUCIT-Systems-and-Development` to `oliver-zehentleitner`, `get_latest_release_info()` still queried the GitHub API using the old org's URL, so the built-in "is an update available" check silently looked at the wrong (now-stale or gone) repo.
 

--- a/context/portfolio-margin.md
+++ b/context/portfolio-margin.md
@@ -3,7 +3,8 @@
 ## Scoped to listenKey/user-data only, no market-data or WS API support
 
 **Status:** active
-**Confirmed** (issue [#452](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/452), commit `b53277f2`)
+**Evidence:** confirmed
+**Source:** issue [#452](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/452), commit `b53277f2`
 
 `binance.com-portfolio_margin` only supports the user-data stream lifecycle (`wss://fstream.binance.com/pm/ws/<listenKey>`, listenKey acquired/kept-alive/closed via UBRA's PAPI methods). There is no `websocket_api_base_uri` (no WS API/order placement) and no public market-data endpoint for this exchange.
 
@@ -12,7 +13,8 @@
 ## Deliberately outside `BINANCE_FUTURES_EXCHANGES`
 
 **Status:** active
-**Confirmed** (commit `b53277f2`: "deliberately outside BINANCE_FUTURES_EXCHANGES")
+**Evidence:** confirmed
+**Source:** commit `b53277f2`: "deliberately outside BINANCE_FUTURES_EXCHANGES"
 
 **Rejected alternative:** folding `binance.com-portfolio_margin` into the existing `BINANCE_FUTURES_EXCHANGES` group, since it's futures-adjacent and could reuse that code path.
 
@@ -21,7 +23,8 @@
 ## Follow-up: graceful degradation for the not-yet-released dependency
 
 **Status:** active
-**Confirmed** (commit `f44ee416`, found during self-review of PR #453)
+**Evidence:** confirmed
+**Source:** commit `f44ee416`, found during self-review of PR #453
 
 `_init_ubra()` previously let UBRA's `UnknownExchange` exception propagate uncaught whenever the installed UBRA version didn't yet recognize `binance.com-portfolio_margin` (true for any UBRA release before PAPI support landed). That crashed the calling stream thread instead of degrading to `(None, None)`, which is what the surrounding `AttributeError` handling was already designed to produce. `get_listen_key()`, `keepalive_listen_key()`, and `delete_listen_key()` now check `_init_ubra()`'s return value and bail out cleanly instead.
 


### PR DESCRIPTION
## Summary
- `context/README.md`: adopt new Keep the Why template (linked logo, "Project context" heading, Reading the entries + Trust boundary sections, links to `index.md`)
- `AGENTS.md`: backfill `context-schema: 0.5.1` and `capture-confirmation: confirm-when-unsure` in the project config block (both fields were missing entirely)
- `context/`: migrate existing entries to the 0.3.0 Status/Evidence split — `**Confirmed** (X)` becomes `**Evidence:** confirmed` + `**Source:** X`

No content/rationale changes — pure schema/template migration, aligning with Keep the Why v0.5.1.