### PR TITLE
docs(changelog): log testnet WS-API URL fix under 2.15.0.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
   [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/readme.html#installation-and-upgrade)
 
-## 2.15.1.dev (development stage/unreleased/unstable)
+## 2.15.0.dev (development stage/unreleased/unstable)
 ### Fixed
 - Testnet WebSocket API base URL: Binance moved the Spot/Margin/Isolated-
   Margin testnet WS-API endpoint to a dedicated `ws-api.` subdomain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
   [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/readme.html#installation-and-upgrade)
 
-## 2.15.0.dev (development stage/unreleased/unstable)
+## 2.15.1.dev (development stage/unreleased/unstable)
+### Fixed
+- Testnet WebSocket API base URL: Binance moved the Spot/Margin/Isolated-
+  Margin testnet WS-API endpoint to a dedicated `ws-api.` subdomain
+  (`wss://ws-api.testnet.binance.vision/ws-api/v3`, was
+  `wss://testnet.binance.vision/ws-api/v3`). The general stream endpoint and
+  the Futures testnet WS-API are unaffected.
+  ([issue #459](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/459),
+  [PR #460](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/pull/460))
 
 ## 2.15.0
 ### Added


### PR DESCRIPTION
## Summary
Adds a `### Fixed` entry under the existing `2.15.0.dev` dev-stage header for the testnet WS-API URL fix merged in #460. Dev-stage header stays at `2.15.0.dev` — the next version number isn't decided yet, that happens at release time.

No code changes, no version bump in `setup.py`/`pyproject.toml`.

Refs #459, #460