### PR TITLE
Fix testnet WebSocket stream base URL (stream.testnet.binance.vision)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Testnet WebSocket API base URL: Binance moved the Spot/Margin/Isolated-
   Margin testnet WS-API endpoint to a dedicated `ws-api.` subdomain
   (`wss://ws-api.testnet.binance.vision/ws-api/v3`, was
-  `wss://testnet.binance.vision/ws-api/v3`). The general stream endpoint and
-  the Futures testnet WS-API are unaffected.
+  `wss://testnet.binance.vision/ws-api/v3`). The Futures testnet WS-API is
+  unaffected.
   ([issue #459](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/459),
   [PR #460](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/pull/460))
+- Testnet WebSocket stream base URL: Binance also moved the Spot/Margin/
+  Isolated-Margin testnet market data stream endpoint to the `stream.`
+  subdomain (`wss://stream.testnet.binance.vision/`, was
+  `wss://testnet.binance.vision/`, which now 404s). Confirmed via a live
+  WebSocket handshake against both hosts.
+  ([issue #459](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/459))
 
 ## 2.15.0
 ### Added

--- a/unicorn_binance_websocket_api/connection_settings.py
+++ b/unicorn_binance_websocket_api/connection_settings.py
@@ -90,7 +90,7 @@ CONNECTION_SETTINGS = {
     ),
     Exchanges.BINANCE_TESTNET: (
         1024,
-        "wss://testnet.binance.vision/",
+        "wss://stream.testnet.binance.vision/",
         "wss://ws-api.testnet.binance.vision/ws-api/v3",
     ),
     Exchanges.BINANCE_MARGIN: (
@@ -100,7 +100,7 @@ CONNECTION_SETTINGS = {
     ),
     Exchanges.BINANCE_MARGIN_TESTNET: (
         1024,
-        "wss://testnet.binance.vision/",
+        "wss://stream.testnet.binance.vision/",
         "wss://ws-api.testnet.binance.vision/ws-api/v3",
     ),
     Exchanges.BINANCE_ISOLATED_MARGIN: (
@@ -110,7 +110,7 @@ CONNECTION_SETTINGS = {
     ),
     Exchanges.BINANCE_ISOLATED_MARGIN_TESTNET: (
         1024,
-        "wss://testnet.binance.vision/",
+        "wss://stream.testnet.binance.vision/",
         "wss://ws-api.testnet.binance.vision/ws-api/v3",
     ),
     Exchanges.BINANCE_FUTURES: (

--- a/unittest_binance_websocket_api.py
+++ b/unittest_binance_websocket_api.py
@@ -436,25 +436,25 @@ class TestBinanceComManagerTest(unittest.TestCase):
     def test_create_uri_miniticker_regular_com(self):
         self.assertEqual(
             self.__class__.ubwa.create_websocket_uri(["!miniTicker"], ["arr"]),
-            "wss://testnet.binance.vision/ws/!miniTicker@arr",
+            "wss://stream.testnet.binance.vision/ws/!miniTicker@arr",
         )
 
     def test_create_uri_miniticker_reverse_com(self):
         self.assertEqual(
             self.__class__.ubwa.create_websocket_uri(["arr"], ["!miniTicker"]),
-            "wss://testnet.binance.vision/ws/!miniTicker@arr",
+            "wss://stream.testnet.binance.vision/ws/!miniTicker@arr",
         )
 
     def test_create_uri_ticker_regular_com(self):
         self.assertEqual(
             self.__class__.ubwa.create_websocket_uri(["!ticker"], ["arr"]),
-            "wss://testnet.binance.vision/ws/!ticker@arr",
+            "wss://stream.testnet.binance.vision/ws/!ticker@arr",
         )
 
     def test_create_uri_ticker_reverse_com(self):
         self.assertEqual(
             self.__class__.ubwa.create_websocket_uri(["arr"], ["!ticker"]),
-            "wss://testnet.binance.vision/ws/!ticker@arr",
+            "wss://stream.testnet.binance.vision/ws/!ticker@arr",
         )
 
     def test_create_uri_userdata_regular_false_com(self):


### PR DESCRIPTION
## Summary
- Binance also moved the Spot/Margin/Isolated-Margin testnet **market data stream** endpoint to the `stream.` subdomain — same migration as the WS-API fix in #460, just a different host.
- Old: `wss://testnet.binance.vision/` → now 404s (confirmed via a live WebSocket handshake).
- New: `wss://stream.testnet.binance.vision/` → confirmed live, streams real trade data.
- Updates `connection_settings.py` for `BINANCE_TESTNET`, `BINANCE_MARGIN_TESTNET`, `BINANCE_ISOLATED_MARGIN_TESTNET`, the affected unit tests, and the CHANGELOG (corrects the earlier note in #460 that claimed the stream endpoint was unaffected).

Reported by @jsenjobs on #459.

## Test plan
- [x] `pytest unittest_binance_websocket_api.py::TestBinanceComManagerTest -k "miniticker or ticker"` — 4 passed
- [x] Live WebSocket handshake against both old and new host confirms old host 404s, new host is alive