### PR TITLE
docs: prepare 2.15.1 release (changelog + llms.txt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
   [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/readme.html#installation-and-upgrade)
 
-## 2.15.0.dev (development stage/unreleased/unstable)
+## 2.15.1.dev (development stage/unreleased/unstable)
+
+## 2.15.1
 ### Fixed
 - Testnet WebSocket API base URL: Binance moved the Spot/Margin/Isolated-
   Margin testnet WS-API endpoint to a dedicated `ws-api.` subdomain

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@
 
 Beginner-friendly despite depth — complexity is optional, the API stays clean and Pythonic.
 
-Version: 2.13.0. Python 3.9 – 3.14.
+Version: 2.15.1. Python 3.9 – 3.14.
 
 ## Authorship & License
 


### PR DESCRIPTION
Prep for the 2.15.1 bugfix release (issue #459, PRs #460/#462):

- CHANGELOG.md: rename the floating dev header from `2.15.0.dev` to
  `2.15.1.dev` and insert a `## 2.15.1` release section below it,
  containing the two testnet URL fixes (was: sitting directly under
  the `.dev` header).
- llms.txt: bump the stale version line (`2.13.0` → `2.15.1`); it isn't
  part of `dev/set_version_config.txt` so it never gets touched by the
  version-bump script and had drifted two releases behind.

No code changes. Version bump (setup.py, meta.yaml, etc.) still to be
done via `dev/set_version.py`.