### PR TITLE
chore(ktw): bump context-schema to 0.8.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,6 @@ async def main():
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.5.1
+- context-schema: 0.8.0
 - capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->

--- a/context/README.md
+++ b/context/README.md
@@ -24,6 +24,7 @@ For usage, installation, operation, or troubleshooting, see `docs/`.
 
 Each entry separates:
 
+- **Type** — what kind of thing it is: decision, workaround, incident, or constraint (or undefined, with a reason, if none fit)
 - **Status** — whether a decision is active, superseded, open, or needs review
 - **Evidence** — whether its rationale is confirmed, inferred, or unknown
 

--- a/context/history.md
+++ b/context/history.md
@@ -2,6 +2,7 @@
 
 ## Repo origin: LUCIT-Systems-and-Development
 
+**Type:** decision
 **Status:** superseded — repo now lives under `oliver-zehentleitner`
 **Evidence:** confirmed
 **Source:** git history; earliest commits reference `github.com/LUCIT-Systems-and-Development/unicorn-binance-websocket-api`
@@ -14,6 +15,7 @@ The repo was previously hosted under the `LUCIT-Systems-and-Development` GitHub 
 
 ## Icinga/monitoring REST server removed, not just rebranded
 
+**Type:** decision
 **Status:** active
 **Evidence:** confirmed
 **Source:** commit `ee615105`
@@ -26,6 +28,7 @@ The repo was previously hosted under the `LUCIT-Systems-and-Development` GitHub 
 
 ## Hardcoded LUCIT org URL broke `get_latest_release_info()`
 
+**Type:** incident
 **Status:** superseded — fixed
 **Evidence:** confirmed
 **Source:** commit `c2eb03ac`

--- a/context/portfolio-margin.md
+++ b/context/portfolio-margin.md
@@ -2,6 +2,7 @@
 
 ## Scoped to listenKey/user-data only, no market-data or WS API support
 
+**Type:** constraint
 **Status:** active
 **Evidence:** confirmed
 **Source:** issue [#452](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/452), commit `b53277f2`
@@ -12,6 +13,7 @@
 
 ## Deliberately outside `BINANCE_FUTURES_EXCHANGES`
 
+**Type:** decision
 **Status:** active
 **Evidence:** confirmed
 **Source:** commit `b53277f2`: "deliberately outside BINANCE_FUTURES_EXCHANGES"
@@ -22,6 +24,7 @@
 
 ## Follow-up: graceful degradation for the not-yet-released dependency
 
+**Type:** workaround
 **Status:** active
 **Evidence:** confirmed
 **Source:** commit `f44ee416`, found during self-review of PR #453


### PR DESCRIPTION
Migrates the project's keep-the-why context-schema from its previous value to 0.8.0.

- Bumps `context-schema` in AGENTS.md.
- Adds the Type field line to `context/README.md`'s "Reading the entries" section (0.7.0/0.8.0 migration step).

Individual context/ entries are not backfilled in bulk — per the skill's migration guidance, an entry picks up a Type value the next time it's touched anyway, not as a dedicated pass.