### PR TITLE
fix: SOCKS5 proxy connects to wrong host for WS API / userData streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/readme.html#installation-and-upgrade)
 
 ## 2.15.1.dev (development stage/unreleased/unstable)
+### Fixed
+- SOCKS5 proxy connections used `websocket_base_uri` to determine the proxy
+  target host, instead of the actual stream URI. This was wrong for
+  WebSocket API streams and the WS API userData subscription flow, which
+  connect to `websocket_api_base_uri` — a different host
+  (e.g. `ws-api.binance.com` vs. `stream.binance.com`). Any SOCKS5 proxy
+  user with such a stream had the proxy tunnel opened to the wrong host.
+  ([issue #467](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/467))
 
 ## 2.15.1
 ### Fixed

--- a/unicorn_binance_websocket_api/connection.py
+++ b/unicorn_binance_websocket_api/connection.py
@@ -162,7 +162,10 @@ class BinanceWebSocketApiConnection(object):
                 username=self.manager.socks5_proxy_user,
                 password=self.manager.socks5_proxy_pass,
             )
-            netloc = urlparse(self.manager.websocket_base_uri).netloc
+            # Use the actual stream URI, not `websocket_base_uri`: for WebSocket API
+            # streams and the WS API userData subscription flow, `uri` resolves to
+            # `websocket_api_base_uri`, a different host (see connection_settings.py).
+            netloc = urlparse(str(uri)).netloc
             try:
                 host, port = netloc.split(":")
             except ValueError as error_msg:


### PR DESCRIPTION
## Summary
- `connection.py` derived the SOCKS5 proxy target host from `websocket_base_uri`, fixed per exchange.
- WebSocket API streams and the WS API userData subscription flow (Binance, Testnet, Margin, Isolated Margin) connect to `websocket_api_base_uri` instead - a different host (`ws-api.binance.com` vs. `stream.binance.com`).
- SOCKS5 proxy users with such a stream had the proxy tunnel opened to the wrong host, while the actual connection targeted the other one. The non-proxy code path already used the correct URI.
- Fix: use the actual stream URI (`str(uri)`) to derive the proxy netloc, matching the non-proxy path.

Fixes #467