### PR TITLE
chore: bump keep-the-why context-schema to 0.9.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,6 @@ async def main():
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.9.0
+- context-schema: 0.9.2
 - capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
## Summary
- Bookkeeping only: 0.9.1/0.9.2 introduced no context/ format changes, so no migration needed.
- Bumps context-schema in AGENTS.md to match the installed skill version.