### PR TITLE
chore: bump keep-the-why context-schema to 0.16.0

### DIFF
--- a/.keep-the-why
+++ b/.keep-the-why
@@ -6,7 +6,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---unicorn-binance-websocket-api
 - context: `context/`
 - init: complete
-- context-schema: 0.14.0
+- context-schema: 0.16.0
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Suite-wide keep-the-why update 0.14.0 → 0.16.0.

- Only change: `context-schema: 0.16.0` in `.keep-the-why`.
- The 0.15.0 and 0.16.0 entries in migrations.md are informational (new wizard defaults for fresh setups, Codex plugin install route) — nothing to migrate in `context/`.
- CI linting snippet and `context/README.md` template unchanged between v0.14.0 and v0.16.0 (checked via git diff in the skill repo).
- `ktw-lint 0.16.0.0 --strict`: 0 errors / 0 warnings before and after.