### PR TITLE
feat: optional picows support via websocket_library switch

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements.txt picows
         pip install coveralls
 
     - name: Unit test
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements.txt picows
         pip install coveralls
 
     - name: Unit test
@@ -58,7 +58,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements.txt picows
         pip install coveralls
 
     - name: Unit test
@@ -77,7 +77,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements.txt picows
         pip install coveralls
 
     - name: Unit test
@@ -96,7 +96,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements.txt picows
         pip install coveralls
 
     - name: Unit test
@@ -123,7 +123,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements.txt picows
         pip install coveralls
 
     - name: Unit test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Python SDK (MIT License) for connecting to Binance WebSocket streams. Enables mu
 unicorn_binance_websocket_api/     # Main package
     manager.py                     # Core class BinanceWebSocketApiManager (~4800 lines)
     connection.py                  # Individual WebSocket connections (asyncio)
+    websocket_library.py           # websockets (default) vs. picows selection + exception families
     sockets.py                     # Socket implementation with stream processing
     restclient.py                  # REST client for stream management
     connection_settings.py         # Exchanges enum + connection parameters
@@ -75,6 +76,10 @@ and deliberately not part of `BINANCE_FUTURES_EXCHANGES`:
 Managed in `requirements.txt`, `setup.py`, and `pyproject.toml` — **all three must be kept in sync manually** (IDE find/replace):
 
 - `websocket-client`, `websockets>=14.0` — WebSocket connections
+- `picows>=2.1.0` — **optional** (extra `picows`), alternative WebSocket library via its
+  `websockets`-compatible API; selected with `BinanceWebSocketApiManager(websocket_library="picows")`,
+  see [`context/websocket-library.md`](context/websocket-library.md). Benchmark:
+  `dev/test_websocket_library_benchmark.py`
 - `requests>=2.31.0` — HTTP
 - `orjson` — fast JSON serialization
 - `unicorn-fy>=0.15.0` — stream data normalization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api/readme.html#installation-and-upgrade)
 
 ## 2.15.2.dev (development stage/unreleased/unstable)
+### Added
+- Optional support for [`picows`](https://github.com/tarasko/picows) as WebSocket
+  client library, selected per manager instance with
+  `BinanceWebSocketApiManager(websocket_library="picows")` (default stays
+  `"websockets"`). Uses picows' `websockets`-compatible API
+  (`picows.websockets`, picows >= 2.1.0), so the connection handling is shared
+  and only `connect()` plus the exception families differ
+  (`unicorn_binance_websocket_api/websocket_library.py`). Install with
+  `pip install unicorn-binance-websocket-api[picows]`. Selecting `"picows"`
+  without the package raises `ImportError`, unknown values raise `ValueError`.
+  Benchmark script and results: `dev/test_websocket_library_benchmark.py`,
+  [`context/websocket-library.md`](context/websocket-library.md).
 
 ## 2.15.2
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -441,6 +441,9 @@ rich media, shell syntax, tab completion, and history."
 
 - Customizable base URL.
 
+- Choice of the WebSocket engine: [`websockets`](https://websockets.readthedocs.io) (default) or
+  [`picows`](https://github.com/tarasko/picows), see [WebSocket library](#websocket-library-websockets-or-picows).
+
 - *Socks5 Proxy* support:
 
   ```
@@ -508,6 +511,51 @@ this may take some time!
 ```
 conda install -c conda-forge unicorn-binance-websocket-api
 ```
+
+### WebSocket library: `websockets` or `picows`
+UBWA uses the [`websockets`](https://websockets.readthedocs.io) library by default. Alternatively it can run on
+[`picows`](https://github.com/tarasko/picows), a Cython implementation of the WebSocket protocol that ships a
+drop-in replacement of the `websockets` client API (`picows.websockets`). `picows` is an optional dependency:
+
+```
+pip install unicorn-binance-websocket-api[picows]
+```
+
+Select the library per manager instance, everything else stays the same:
+
+```
+ubwa = BinanceWebSocketApiManager(exchange="binance.com", websocket_library="picows")
+```
+
+Selecting `"picows"` without the package installed raises an `ImportError`, an unknown value raises a `ValueError` -
+there is no silent fallback. SOCKS5 proxies work with both libraries. The [conda-forge](https://anaconda.org/conda-forge/picows)
+package is `picows`.
+
+#### Is `picows` faster? Measured, not assumed
+`dev/test_websocket_library_benchmark.py` replays Binance shaped messages from a local server (separate process)
+through the complete UBWA stack (connection → stream loop → `process_stream_data` callback), 3 runs, median.
+Python 3.13, websockets 16.0, picows 2.1.3, x86_64 Linux, `output_default="raw_data"`:
+
+| Scenario | ~msg size | msgs | websockets msgs/s | picows msgs/s | picows speedup | websockets CPU µs/msg | picows CPU µs/msg |
+|---|---|---|---|---|---|---|---|
+| small_aggtrade | 0.2 KB | 300,000 | 116,314 | 163,406 | 1.40x | 8.7 | 6.2 |
+| medium_kline | 0.3 KB | 150,000 | 112,815 | 158,541 | 1.41x | 9.0 | 6.4 |
+| large_depth20 | 1.0 KB | 60,000 | 96,835 | 135,253 | 1.40x | 10.5 | 7.8 |
+| xlarge_depth_diff | 9.1 KB | 30,000 | 50,746 | 51,629 | 1.02x | 20.2 | 20.0 |
+| huge_ticker_arr | 453.9 KB | 600 | 1,753 | 1,597 | 0.91x | 615.9 | 676.9 |
+| multiplex_mix | 0.2 KB | 120,000 | 110,738 | 153,079 | 1.38x | 9.2 | 6.7 |
+
+- Up to ~1 KB per message (aggTrade, kline, bookTicker, depth20, ...) picows delivers **~1.4x** the throughput and
+  needs ~30 % less CPU per message. From ~10 KB upwards (full `depth` diffs, `!ticker@arr`) both are on par - the
+  cost there is UTF-8 decoding and UBWA's own per-message work, not the WebSocket framing.
+- Driven directly, without UBWA, the libraries are 1.5x-2x apart (websockets ~320k msgs/s vs. picows ~490k msgs/s
+  for small messages). UBWA's stream loop adds a constant ~5 µs per message on top of either library, which is why
+  the gap shrinks inside UBWA.
+- Against live binance.com with a 20 symbol multiplex (a few hundred msgs/s) the choice makes no measurable
+  difference: the CPU load is dominated by UBWA's fixed per-manager overhead, not by the transport.
+- So: pick `picows` for high-throughput consumers (many streams, `depth@100ms` on hundreds of symbols, CPU-bound
+  hosts), stay on `websockets` if you need its broader ecosystem. Full tables including `output_default="dict"`
+  and the raw-library baseline: [`context/websocket-library.md`](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/blob/master/context/websocket-library.md).
 
 ### From source of the latest release with PIP from [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api)
 #### Linux, macOS, ...

--- a/context/index.md
+++ b/context/index.md
@@ -62,6 +62,8 @@
 
 ## S
 
+- [stream-loop.md](stream-loop.md) — untimed `recv()` after the first receives (deliberate, `wait_for` overhead; stop latency on idle streams accepted) and where UBWA's own per-message cost sits
+
 ## T
 
 ## U

--- a/context/index.md
+++ b/context/index.md
@@ -70,6 +70,8 @@
 
 ## W
 
+- [websocket-library.md](websocket-library.md) — why `picows` is integrated via its `websockets`-compatible API (not the core listener API), separate exception families, fail-loud selection, shared SOCKS5 path, and the benchmark numbers behind it
+
 ## X
 
 ## Y

--- a/context/stream-loop.md
+++ b/context/stream-loop.md
@@ -1,0 +1,51 @@
+# Stream loop (`sockets.py` / `connection.py`)
+
+## `recv()` runs without timeout after the first receives - `stop_stream()` waits for the next message
+
+**Type:** decision
+**Status:** active
+**Evidence:** confirmed
+**Source:** maintainer confirmation 2026-09-10; `connection.py` (`timeout_disabled`), git history: threshold `processed_receives_total > 3` predates commit `fd370d8a` (2024-03-27, which added the `timeout_disabled` flag), today `> 10`
+
+`BinanceWebSocketApiConnection.receive()` wraps `recv()` in
+`asyncio.wait_for(..., timeout=1)` only until a stream has more than 10
+processed receives; from then on, as long as the stream has subscriptions,
+it awaits `recv()` without a timeout. `stop_stream()` merely sets
+`stop_request`, which `receive()` checks at the top of each call.
+Consequence: on a stream that has subscriptions but currently receives
+nothing, a stop (or crash request) takes effect only when the next message
+arrives - or when the peer closes. Against Binance this is invisible because
+data keeps flowing; it surfaced in the local-server unit test for the
+websocket-library switch, where the test server had to send a heartbeat for
+the manager to shut down.
+
+**Reason:** deliberate. `wait_for()` costs a task plus a timer per message,
+which is not wanted on the hot path once a stream is known to be alive. The
+timed phase at the start exists for the opposite case: a loop that never
+receives anything (bad subscription, dead endpoint) must still be stoppable,
+so the first receives are polled with a 1 s timeout until the stream has
+proven it delivers data.
+
+**Accepted consequence:** the stop latency on an established but currently
+idle stream is acceptable to the maintainer; not a bug.
+
+**Rejected alternative:** keeping a (long) timeout permanently - rejected
+because of the per-message overhead. Closing the websocket from
+`stop_stream()` directly was not in contention.
+
+## Per-message work in the loop that is not the transport
+
+**Type:** constraint
+**Status:** active
+**Evidence:** inferred
+**Source:** `websocket-library.md` "Benchmark results"; code reading of `connection.py` / `sockets.py`
+
+The benchmark for the websocket-library switch showed a constant ~5 µs per
+message that UBWA spends on top of either library (raw libraries 2-3 µs/msg,
+through UBWA 6-9 µs/msg). Not profiled yet; visible per-message work in the
+code: `sys.getsizeof(str(...))` byte accounting plus three lock-protected
+counters in `receive()`, the `wait_for()` wrapper on early receives,
+substring checks (`"error" in`, `"result" in`, `userdata_subscribe_id in`)
+over the raw JSON string, and the dispatch cascade in `start_socket()`.
+Recorded so that a future optimization pass starts from the measurement
+rather than from the transport.

--- a/context/websocket-library.md
+++ b/context/websocket-library.md
@@ -1,0 +1,150 @@
+# WebSocket library: `websockets` (default) or `picows`
+
+## Integrated via `picows.websockets`, not via the picows core API
+
+**Type:** decision
+**Status:** active
+**Evidence:** confirmed
+**Source:** branch `feature/websocket-library-picows`, benchmark `dev/test_websocket_library_benchmark.py`
+
+`BinanceWebSocketApiManager(websocket_library="picows")` swaps the transport
+for the whole manager instance. The integration goes through
+`picows.websockets` (picows >= 2.0.0), which is a drop-in replacement of the
+`websockets` client API: same `connect()` signature, same `recv()`/`send()`/
+`close()` on the connection object, same exception names. All the selection
+logic lives in `unicorn_binance_websocket_api/websocket_library.py`;
+`connection.py` only asks it for the `connect()` callable and `manager.py`
+catches both exception families.
+
+**Reason:** UBWA's per-stream loop (`sockets.py`) is written against the
+`websockets` API - `await recv()` wrapped in `asyncio.wait_for()`, one
+coroutine per stream in its own thread/event loop. Reusing that path means
+zero duplicated stream logic and no second code path to keep in sync.
+
+**Rejected alternative:** a "native" integration on picows' core API
+(`ws_connect()` + a `WSListener` with `on_ws_frame()` callbacks). It would
+avoid the pull-based `recv()` queue and the asyncio wake-up per message, and
+is where picows gets its headline numbers. It was rejected *for now* because
+it is a second connection implementation: a callback-to-coroutine bridge
+(queue or futures) that has to reproduce `wait_for()` cancellation semantics,
+fragmented-frame reassembly, close-handshake and ping/pong handling that
+`picows.websockets` already provides. The measured gain of the compat layer
+inside UBWA is real but moderate (see below), and the remaining overhead is
+mostly UBWA's own per-message work, not the transport - so the extra
+complexity would not pay off until that is addressed.
+
+**Revisit when:** UBWA's per-message pipeline (`sys.getsizeof(str(...))`
+byte accounting, the `wait_for()` wrapper, the stats counters) is slimmed
+down, or picows exposes a zero-copy path for `picows.websockets`.
+
+## Why the picows exception classes are caught separately
+
+**Type:** constraint
+**Status:** active
+**Evidence:** confirmed
+**Source:** `picows/websockets/exceptions.py` (picows 2.1.3)
+
+`picows.websockets.exceptions.ConnectionClosed` & co. are *not* subclasses of
+the `websockets` exception classes, they only share the names. The manager's
+restart logic therefore catches tuples
+(`CONNECTION_CLOSED_EXCEPTIONS`, ...) built in `websocket_library.py`; the
+picows classes are appended only when the package is importable.
+
+## Fail loud on `picows` without the package
+
+**Type:** decision
+**Status:** active
+**Evidence:** confirmed
+
+Selecting `"picows"` without the optional dependency raises `ImportError`,
+an unknown value raises `ValueError` - no silent fallback to `websockets`.
+Follows the suite-wide "fail loud" rule: a deployment that thinks it runs
+picows but silently runs websockets is a hidden configuration bug.
+
+## SOCKS5 proxy path is shared
+
+**Type:** decision
+**Status:** active
+**Evidence:** confirmed
+
+Both libraries get the pre-connected PySocks socket via `sock=` +
+`server_hostname=` (UBWA's existing SOCKS5 handling). For picows the
+`proxy=None` kwarg is passed explicitly on that path, because
+`picows.websockets.connect()` defaults to `proxy=True` (environment
+`wss_proxy`/`https_proxy` lookup) and would otherwise try a second proxy hop
+over the already tunneled socket. picows' own proxy support (`socks5://`
+URLs via python-socks, HTTPS proxies still a draft in
+[tarasko/picows#80](https://github.com/tarasko/picows/pull/80)) is
+deliberately not used, so proxy behaviour is identical for both libraries.
+
+## Benchmark results
+
+**Type:** decision
+**Status:** active
+**Evidence:** confirmed
+**Source:** `dev/test_websocket_library_benchmark.py`, run on the branch
+
+Setup: `dev/test_websocket_library_benchmark.py`, Python 3.13.5, x86_64 Linux
+(4 cores), websockets 16.0, picows 2.1.3, UBWA 2.15.2.dev. A picows based
+replay server in a separate process pushes pre-serialized Binance shaped
+messages as fast as it can; "CPU µs/msg" is the client process' CPU time
+(`time.process_time()`) divided by messages, so the server's cost is
+excluded. 3 runs each, median.
+
+**Libraries driven directly (`async for msg in ws`, no UBWA):**
+
+| Scenario | ~msg size | msgs | websockets msgs/s | picows msgs/s | picows speedup | websockets CPU µs/msg | picows CPU µs/msg |
+|---|---|---|---|---|---|---|---|
+| small_aggtrade | 0.2 KB | 300,000 | 326,982 | 493,206 | 1.51x | 3.1 | 2.0 |
+| medium_kline | 0.3 KB | 150,000 | 316,559 | 491,393 | 1.55x | 3.2 | 2.0 |
+| large_depth20 | 1.0 KB | 60,000 | 280,948 | 465,901 | 1.66x | 3.6 | 2.2 |
+| xlarge_depth_diff | 9.1 KB | 30,000 | 143,760 | 283,667 | 1.97x | 7.0 | 3.5 |
+| huge_ticker_arr | 453.9 KB | 600 | 5,842 | 6,698 | 1.15x | 172.5 | 140.7 |
+| multiplex_mix | 0.2 KB | 120,000 | 304,762 | 470,529 | 1.54x | 3.3 | 2.1 |
+
+**Through UBWA, `output_default="raw_data"` (callback receives the JSON string):**
+
+| Scenario | ~msg size | msgs | websockets msgs/s | picows msgs/s | picows speedup | websockets CPU µs/msg | picows CPU µs/msg |
+|---|---|---|---|---|---|---|---|
+| small_aggtrade | 0.2 KB | 300,000 | 116,314 | 163,406 | 1.40x | 8.7 | 6.2 |
+| medium_kline | 0.3 KB | 150,000 | 112,815 | 158,541 | 1.41x | 9.0 | 6.4 |
+| large_depth20 | 1.0 KB | 60,000 | 96,835 | 135,253 | 1.40x | 10.5 | 7.8 |
+| xlarge_depth_diff | 9.1 KB | 30,000 | 50,746 | 51,629 | 1.02x | 20.2 | 20.0 |
+| huge_ticker_arr | 453.9 KB | 600 | 1,753 | 1,597 | 0.91x | 615.9 | 676.9 |
+| multiplex_mix | 0.2 KB | 120,000 | 110,738 | 153,079 | 1.38x | 9.2 | 6.7 |
+
+**Through UBWA, `output_default="dict"` (plus `orjson.loads()`):**
+
+| Scenario | ~msg size | msgs | websockets msgs/s | picows msgs/s | picows speedup | websockets CPU µs/msg | picows CPU µs/msg |
+|---|---|---|---|---|---|---|---|
+| small_aggtrade | 0.2 KB | 300,000 | 108,738 | 146,053 | 1.34x | 9.3 | 6.9 |
+| medium_kline | 0.3 KB | 150,000 | 101,532 | 135,117 | 1.33x | 10.0 | 7.5 |
+| large_depth20 | 1.0 KB | 60,000 | 79,148 | 100,820 | 1.27x | 13.1 | 10.4 |
+| xlarge_depth_diff | 9.1 KB | 30,000 | 22,118 | 23,302 | 1.05x | 46.1 | 43.2 |
+| huge_ticker_arr | 453.9 KB | 600 | 357 | 397 | 1.11x | 2871.3 | 2617.6 |
+| multiplex_mix | 0.2 KB | 120,000 | 86,168 | 113,088 | 1.31x | 11.8 | 9.0 |
+
+**Live binance.com, 20 symbol multiplex + `!ticker@arr`/`!miniTicker@arr` + 10x `depth`, 60 s each, sequential:**
+
+| Library | msgs/s | MB/s | CPU % of one core | CPU µs/msg |
+|---|---|---|---|---|
+| websockets | 441 | 0.20 | 8.7 | 198.1 |
+| picows | 306 | 0.16 | 6.1 | 199.2 |
+
+**Reading:**
+
+- Small and medium messages (<= ~1 KB, the bulk of Binance traffic): picows
+  ~1.4x throughput and ~30 % less CPU per message inside UBWA. Standalone the
+  libraries are 1.5x-2x apart.
+- >= ~10 KB (full `depth` diffs, `!ticker@arr`): parity inside UBWA (0.9x-1.1x,
+  within run-to-run noise). Cost there is dominated by UTF-8 decoding of the
+  payload plus UBWA's substring checks (`"error" in ...`, `"result" in ...`)
+  and byte accounting over the whole message.
+- UBWA adds a constant ~5 µs per message on top of either library
+  (3.1 -> 8.7 µs for websockets, 2.0 -> 6.2 µs for picows). That is the
+  bigger lever: the transport is at most a third of the per-message cost.
+- Live at a few hundred msgs/s the numbers are identical (~198 µs CPU/msg for
+  both) because the manager's fixed overhead (monitoring loops, per-stream
+  event loops, keepalive) dominates; message rate differs between the two
+  windows only because market activity differs. Library choice only matters
+  for high-throughput consumers or CPU-bound hosts.

--- a/context/websocket-library.md
+++ b/context/websocket-library.md
@@ -5,37 +5,64 @@
 **Type:** decision
 **Status:** active
 **Evidence:** confirmed
-**Source:** branch `feature/websocket-library-picows`, benchmark `dev/test_websocket_library_benchmark.py`
+**Source:** maintainer instruction for the feature ("compatibility mode to the websockets API"), branch `feature/websocket-library-picows`, PR #475
 
 `BinanceWebSocketApiManager(websocket_library="picows")` swaps the transport
 for the whole manager instance. The integration goes through
-`picows.websockets` (picows >= 2.0.0), which is a drop-in replacement of the
+`picows.websockets` (picows >= 2.0.0), a drop-in replacement of the
 `websockets` client API: same `connect()` signature, same `recv()`/`send()`/
 `close()` on the connection object, same exception names. All the selection
 logic lives in `unicorn_binance_websocket_api/websocket_library.py`;
 `connection.py` only asks it for the `connect()` callable and `manager.py`
-catches both exception families.
+catches both exception families. `sockets.py` (the stream loop) is untouched.
 
-**Reason:** UBWA's per-stream loop (`sockets.py`) is written against the
-`websockets` API - `await recv()` wrapped in `asyncio.wait_for()`, one
-coroutine per stream in its own thread/event loop. Reusing that path means
-zero duplicated stream logic and no second code path to keep in sync.
+**Reason:** the stream loop is written against the `websockets` API -
+`await recv()` wrapped in `asyncio.wait_for()`, one coroutine per stream in
+its own thread/event loop. Reusing that path means zero duplicated stream
+logic and no second code path to keep in sync. Chosen as the first step
+explicitly; a native integration was to be *assessed*, not built (next entry).
 
-**Rejected alternative:** a "native" integration on picows' core API
-(`ws_connect()` + a `WSListener` with `on_ws_frame()` callbacks). It would
-avoid the pull-based `recv()` queue and the asyncio wake-up per message, and
-is where picows gets its headline numbers. It was rejected *for now* because
-it is a second connection implementation: a callback-to-coroutine bridge
-(queue or futures) that has to reproduce `wait_for()` cancellation semantics,
-fragmented-frame reassembly, close-handshake and ping/pong handling that
-`picows.websockets` already provides. The measured gain of the compat layer
-inside UBWA is real but moderate (see below), and the remaining overhead is
-mostly UBWA's own per-message work, not the transport - so the extra
-complexity would not pay off until that is addressed.
+**Version floor `picows>=2.1.0`** rather than 2.0.0 (where `picows.websockets`
+first appeared): 2.1.0 completed the compat surface (`open`/`closed`
+attributes, `protocol.State`, `WebSocketClientProtocol` alias). UBWA does not
+use those today; the floor buys the complete API in case it does. Evidence
+for this sub-choice: inferred from the picows release notes.
 
-**Revisit when:** UBWA's per-message pipeline (`sys.getsizeof(str(...))`
-byte accounting, the `wait_for()` wrapper, the stats counters) is slimmed
-down, or picows exposes a zero-copy path for `picows.websockets`.
+## Native picows core API (`ws_connect()` + `WSListener`) - assessed, not built
+
+**Type:** decision
+**Status:** open
+**Evidence:** inferred
+**Source:** benchmark `dev/test_websocket_library_benchmark.py` (`--raw-libs` vs. through-UBWA runs), assessment in PR #475
+
+The alternative to the compat layer is a push-model integration on picows'
+core API: `ws_connect()` with a `WSListener` whose `on_ws_frame()` callback
+does the dispatch directly, no `recv()` queue and no coroutine wake-up per
+message. That is where picows' headline numbers come from.
+
+**Assessment (inferred, not yet decided by the maintainer):**
+
+- A bridge variant (callback -> `asyncio.Queue` -> `await queue.get()` in the
+  existing loop) gains nothing: `picows.websockets` already does exactly that,
+  in Cython. A hand-written Python bridge would be slower or equal.
+- A real push variant means a second stream implementation: the dispatch
+  logic of `sockets.py` (buffer/callback/queue routing, WS-API response
+  matching, userData ack, signals, restart semantics) moved into the
+  callback, plus frame reassembly (CONTINUATION/fin), close handshake, a
+  timer replacing the `wait_for()` heartbeat, the send loop as its own task.
+  Async callbacks and `asyncio_queue.put()` need `create_task()` per message
+  again, which eats part of the gain. Rough size: a 300-400 line connection
+  class, days of work plus soak testing, and two diverging loops to maintain.
+- Expected gain is bounded: the coroutine wake-up costs maybe 1-1.5 µs of
+  the 6.2 µs/msg measured with picows through UBWA; the remaining ~4 µs are
+  UBWA's own per-message work (see "Benchmark results" and `stream-loop.md`).
+
+**Recommendation recorded, decision pending:** trim UBWA's own per-message
+overhead first (benefits both libraries, measurable with the benchmark), then
+re-assess the core API against the new baseline.
+
+**Revisit when:** the per-message pipeline has been slimmed down and the
+benchmark re-run, or picows exposes a zero-copy path for `picows.websockets`.
 
 ## Why the picows exception classes are caught separately
 
@@ -66,26 +93,41 @@ picows but silently runs websockets is a hidden configuration bug.
 **Type:** decision
 **Status:** active
 **Evidence:** confirmed
+**Source:** maintainer confirmation 2026-09-10; picows 2.1.3 source (`picows/websockets/asyncio/client.py`, `picows/api.py`); [tarasko/picows#80](https://github.com/tarasko/picows/pull/80); verified locally with a SOCKS5 server + TLS endpoint for both libraries
+**Revisit when:** picows' proxy support matures (HTTPS proxies in #80 land, or its SOCKS path is declared stable) - then re-evaluate whether the picows mode should use the native `proxy=` path
 
 Both libraries get the pre-connected PySocks socket via `sock=` +
 `server_hostname=` (UBWA's existing SOCKS5 handling). For picows the
 `proxy=None` kwarg is passed explicitly on that path, because
 `picows.websockets.connect()` defaults to `proxy=True` (environment
-`wss_proxy`/`https_proxy` lookup) and would otherwise try a second proxy hop
-over the already tunneled socket. picows' own proxy support (`socks5://`
-URLs via python-socks, HTTPS proxies still a draft in
-[tarasko/picows#80](https://github.com/tarasko/picows/pull/80)) is
-deliberately not used, so proxy behaviour is identical for both libraries.
+`wss_proxy`/`https_proxy` lookup) and would otherwise attempt a second proxy
+hop over the already tunneled socket (confirmed by the picows source).
+
+**Reason:** picows is the optional mode; its proxy handling is still moving
+(HTTPS proxies are a draft, the approach was being reworked in #80 at the
+time of writing). The proxy path in the picows mode is therefore allowed to
+evolve with the library instead of being fixed now - sharing UBWA's PySocks
+path keeps behaviour, error mapping (`Socks5ProxyConnectionError`) and
+configuration identical for both libraries until picows has settled.
+
+**Rejected alternative (for now):** picows' own proxy support
+(`proxy="socks5://..."` via python-socks, async, no PySocks). Not rejected
+on merit - deferred until picows' proxy support is stable.
 
 ## Benchmark results
 
-**Type:** decision
+**Type:** constraint
 **Status:** active
 **Evidence:** confirmed
-**Source:** `dev/test_websocket_library_benchmark.py`, run on the branch
+**Source:** `dev/test_websocket_library_benchmark.py`, run on the branch 2026-09-10
+
+The numbers below are measured (confirmed). The "Reading" section is the
+interpretation and is inferred, not separately measured - see the note there.
 
 Setup: `dev/test_websocket_library_benchmark.py`, Python 3.13.5, x86_64 Linux
-(4 cores), websockets 16.0, picows 2.1.3, UBWA 2.15.2.dev. A picows based
+(4 cores), websockets 16.0, picows 2.1.3 with aiofastnet 1.1.0 present (a
+picows dependency; picows uses it for `create_connection` automatically when
+importable, so the picows numbers include it), UBWA 2.15.2.dev. A picows based
 replay server in a separate process pushes pre-serialized Binance shaped
 messages as fast as it can; "CPU µs/msg" is the client process' CPU time
 (`time.process_time()`) divided by messages, so the server's cost is
@@ -131,20 +173,45 @@ excluded. 3 runs each, median.
 | websockets | 441 | 0.20 | 8.7 | 198.1 |
 | picows | 306 | 0.16 | 6.1 | 199.2 |
 
-**Reading:**
+**Reading (inferred):**
 
 - Small and medium messages (<= ~1 KB, the bulk of Binance traffic): picows
   ~1.4x throughput and ~30 % less CPU per message inside UBWA. Standalone the
   libraries are 1.5x-2x apart.
 - >= ~10 KB (full `depth` diffs, `!ticker@arr`): parity inside UBWA (0.9x-1.1x,
-  within run-to-run noise). Cost there is dominated by UTF-8 decoding of the
-  payload plus UBWA's substring checks (`"error" in ...`, `"result" in ...`)
-  and byte accounting over the whole message.
+  within run-to-run noise). Plausible cause, not profiled: UTF-8 decoding of
+  the payload plus UBWA's substring checks (`"error" in ...`,
+  `"result" in ...`) over the whole message dominate, and both libraries pay
+  the same for that.
 - UBWA adds a constant ~5 µs per message on top of either library
   (3.1 -> 8.7 µs for websockets, 2.0 -> 6.2 µs for picows). That is the
   bigger lever: the transport is at most a third of the per-message cost.
+  Where those ~5 µs go has not been profiled; candidates in `stream-loop.md`.
 - Live at a few hundred msgs/s the numbers are identical (~198 µs CPU/msg for
   both) because the manager's fixed overhead (monitoring loops, per-stream
   event loops, keepalive) dominates; message rate differs between the two
   windows only because market activity differs. Library choice only matters
   for high-throughput consumers or CPU-bound hosts.
+
+## Benchmark design choices
+
+**Type:** decision
+**Status:** active
+**Evidence:** confirmed
+**Source:** `dev/test_websocket_library_benchmark.py` docstring and code
+
+Three choices a reader of the numbers should know, all deliberate:
+
+- The replay server runs in a **separate process** and uses the **raw picows
+  server API**, so the client process' CPU time is the client's alone and the
+  sender is faster than either client (a websockets-based server in the same
+  process would cap both clients at the same rate and blur the comparison).
+- Messages are **pre-serialized** (a pool of 500 per scenario) so the server
+  never pays JSON encoding in the hot loop.
+- **CPU µs per message** is reported next to msgs/s because in live mode the
+  rate is set by the exchange; CPU per message is the only number that is
+  comparable across two live windows. Library order alternates per repeat to
+  spread scheduling drift. The live figure still contains the manager's fixed
+  idle cost (monitoring loops, keepalive), which is why it is ~200 µs/msg at
+  a few hundred msgs/s versus ~6-9 µs in the replay - it is not a per-message
+  cost of the transport.

--- a/dev/test_websocket_library_benchmark.py
+++ b/dev/test_websocket_library_benchmark.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# File: dev/test_websocket_library_benchmark.py
+#
+# Part of ‘UNICORN Binance WebSocket API’
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api
+# PyPI: https://pypi.org/project/unicorn-binance-websocket-api
+#
+# Author: Oliver Zehentleitner
+#
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""
+Benchmark: `websockets` vs. `picows` as UBWA's WebSocket client library.
+
+Not part of CI (dev/ only). Two modes:
+
+1. Local replay (default) - deterministic, measures the raw receive path
+   through the whole UBWA stack (connection -> sockets -> callback). A picows
+   based server in a *separate process* pushes pre-serialized Binance-style
+   messages as fast as it can, so the client process' CPU time is the client's
+   alone. Scenarios differ in message size (aggTrade ~200 B ... !ticker@arr
+   ~500 KB) plus a multiplex mix, each repeated `--repeat` times, median is
+   reported.
+
+2. Live (`--live SECONDS`) - both libraries subscribe to the same heavy
+   multiplex on binance.com one after the other. Message rate is dictated by
+   the exchange, so the comparable number is CPU time per received message.
+
+3. Raw libraries (`--raw-libs`) - same local replay, but `websockets` /
+   `picows.websockets` are driven directly (`async for msg in ws`) without
+   UBWA. The gap between this and mode 1 is UBWA's own per-message overhead.
+
+Usage:
+    python3 dev/test_websocket_library_benchmark.py
+    python3 dev/test_websocket_library_benchmark.py --output dict --repeat 5
+    python3 dev/test_websocket_library_benchmark.py --raw-libs
+    python3 dev/test_websocket_library_benchmark.py --live 120
+    python3 dev/test_websocket_library_benchmark.py --markdown results.md
+"""
+
+import os
+import sys
+
+# Prefer the repo checkout over an installed (possibly Cython compiled) UBWA
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from unicorn_binance_websocket_api.manager import (
+    BinanceWebSocketApiManager,
+)  # noqa: E402
+import argparse
+import asyncio
+import logging
+import multiprocessing
+import random
+import statistics
+import threading
+import time
+import urllib.parse
+
+import orjson
+
+logging.getLogger("unicorn_binance_websocket_api").setLevel(logging.ERROR)
+
+LIBRARIES = ("websockets", "picows")
+PORT = 18766
+
+
+# --------------------------------------------------------------------------- #
+# Message generators (Binance shaped JSON)
+# --------------------------------------------------------------------------- #
+def _price():
+    return f"{random.uniform(20000, 70000):.2f}"
+
+
+def _qty():
+    return f"{random.uniform(0.0001, 5):.5f}"
+
+
+def _ts():
+    return int(time.time() * 1000)
+
+
+def msg_aggtrade(i):
+    return {
+        "stream": "btcusdt@aggTrade",
+        "data": {
+            "e": "aggTrade",
+            "E": _ts(),
+            "s": "BTCUSDT",
+            "a": 1000000 + i,
+            "p": _price(),
+            "q": _qty(),
+            "f": 2000000 + i,
+            "l": 2000000 + i,
+            "T": _ts(),
+            "m": bool(i % 2),
+            "M": True,
+        },
+    }
+
+
+def msg_kline(i):
+    return {
+        "stream": "btcusdt@kline_1m",
+        "data": {
+            "e": "kline",
+            "E": _ts(),
+            "s": "BTCUSDT",
+            "k": {
+                "t": _ts(),
+                "T": _ts() + 59999,
+                "s": "BTCUSDT",
+                "i": "1m",
+                "f": 100 + i,
+                "L": 200 + i,
+                "o": _price(),
+                "c": _price(),
+                "h": _price(),
+                "l": _price(),
+                "v": _qty(),
+                "n": 100 + i,
+                "x": False,
+                "q": _qty(),
+                "V": _qty(),
+                "Q": _qty(),
+                "B": "0",
+            },
+        },
+    }
+
+
+def msg_depth20(i):
+    return {
+        "stream": "btcusdt@depth20@100ms",
+        "data": {
+            "lastUpdateId": 5000000000 + i,
+            "bids": [[_price(), _qty()] for _ in range(20)],
+            "asks": [[_price(), _qty()] for _ in range(20)],
+        },
+    }
+
+
+def msg_depth_diff(i, levels=200):
+    return {
+        "stream": "btcusdt@depth",
+        "data": {
+            "e": "depthUpdate",
+            "E": _ts(),
+            "s": "BTCUSDT",
+            "U": 5000000000 + i,
+            "u": 5000000000 + i + levels,
+            "b": [[_price(), _qty()] for _ in range(levels)],
+            "a": [[_price(), _qty()] for _ in range(levels)],
+        },
+    }
+
+
+def msg_ticker_arr(i, symbols=1400):
+    return {
+        "stream": "!ticker@arr",
+        "data": [
+            {
+                "e": "24hrTicker",
+                "E": _ts(),
+                "s": f"SYM{n:04d}USDT",
+                "p": _price(),
+                "P": "1.234",
+                "w": _price(),
+                "x": _price(),
+                "c": _price(),
+                "Q": _qty(),
+                "b": _price(),
+                "B": _qty(),
+                "a": _price(),
+                "A": _qty(),
+                "o": _price(),
+                "h": _price(),
+                "l": _price(),
+                "v": _qty(),
+                "q": _qty(),
+                "O": _ts(),
+                "C": _ts(),
+                "F": 1 + i,
+                "L": 2 + i,
+                "n": 3 + i,
+            }
+            for n in range(symbols)
+        ],
+    }
+
+
+# name -> (generator, number of messages per run)
+SCENARIOS = {
+    "small_aggtrade": (msg_aggtrade, 300_000),
+    "medium_kline": (msg_kline, 150_000),
+    "large_depth20": (msg_depth20, 60_000),
+    "xlarge_depth_diff": (msg_depth_diff, 30_000),
+    "huge_ticker_arr": (msg_ticker_arr, 600),
+    "multiplex_mix": (None, 120_000),
+}
+MULTIPLEX_WEIGHTS = (
+    (msg_aggtrade, 60),
+    (msg_kline, 20),
+    (msg_depth20, 18),
+    (msg_depth_diff, 2),
+)
+POOL_SIZE = 500  # distinct pre-serialized messages per scenario
+
+
+def build_pool(scenario):
+    random.seed(42)
+    generator, _ = SCENARIOS[scenario]
+    pool = []
+    for i in range(POOL_SIZE):
+        if generator is None:
+            gen = random.choices(
+                [g for g, _ in MULTIPLEX_WEIGHTS], [w for _, w in MULTIPLEX_WEIGHTS]
+            )[0]
+        else:
+            gen = generator
+        pool.append(orjson.dumps(gen(i)))
+    return pool
+
+
+# --------------------------------------------------------------------------- #
+# Replay server (separate process, picows raw API = fastest sender available)
+# --------------------------------------------------------------------------- #
+def server_process(port, ready):
+    import picows
+
+    pools = {}
+
+    class Listener(picows.WSListener):
+        def __init__(self, request):
+            path = (
+                request.path.decode()
+                if isinstance(request.path, bytes)
+                else request.path
+            )
+            query = urllib.parse.urlparse(path).query
+            streams = urllib.parse.parse_qs(query).get("streams", [""])[0]
+            # UBWA URI: /stream?streams=<market>@<channel> -> market = scenario
+            self.scenario = streams.split("@")[0].split("/")[0]
+            self.transport = None
+            self.task = None
+
+        def on_ws_connected(self, transport):
+            self.transport = transport
+            self.task = asyncio.get_running_loop().create_task(self.pump())
+
+        async def pump(self):
+            if self.scenario not in SCENARIOS:
+                return
+            if self.scenario not in pools:
+                pools[self.scenario] = build_pool(self.scenario)
+            pool = pools[self.scenario]
+            _, count = SCENARIOS[self.scenario]
+            transport = self.transport
+            n = len(pool)
+            for i in range(count):
+                if transport.is_disconnected:
+                    return
+                transport.send(picows.WSMsgType.TEXT, pool[i % n])
+                if i % 200 == 0:
+                    # let the transport flush, keep the socket buffer honest
+                    await asyncio.sleep(0)
+            # keep the connection open until the client leaves
+
+        def on_ws_frame(self, transport, frame):
+            if frame.msg_type == picows.WSMsgType.TEXT:
+                # answer subscribe/unsubscribe payloads like Binance does
+                try:
+                    request_id = orjson.loads(frame.get_payload_as_bytes())["id"]
+                    transport.send(
+                        picows.WSMsgType.TEXT,
+                        orjson.dumps({"result": None, "id": request_id}),
+                    )
+                except (KeyError, ValueError, TypeError):
+                    pass
+            elif frame.msg_type == picows.WSMsgType.CLOSE:
+                transport.send_close(frame.get_close_code(), frame.get_close_message())
+                transport.disconnect()
+
+        def on_ws_disconnected(self, transport):
+            if self.task is not None:
+                self.task.cancel()
+
+    async def main():
+        server = await picows.ws_create_server(
+            lambda request: Listener(request), "127.0.0.1", port, enable_auto_pong=True
+        )
+        ready.set()
+        async with server:
+            await server.serve_forever()
+
+    asyncio.run(main())
+
+
+# --------------------------------------------------------------------------- #
+# Client side measurement
+# --------------------------------------------------------------------------- #
+class Counter:
+    def __init__(self, target):
+        self.target = target
+        self.count = 0
+        self.bytes = 0
+        self.first = None
+        self.last = None
+        self.done = threading.Event()
+
+    def __call__(self, data):
+        now = time.perf_counter()
+        if self.first is None:
+            self.first = now
+        self.count += 1
+        if isinstance(data, (str, bytes)):
+            self.bytes += len(data)
+        if self.count >= self.target:
+            self.last = now
+            self.done.set()
+
+
+def run_local(library, scenario, output, port):
+    """One measurement: returns dict with wall/cpu/msgs/bytes."""
+    _, count = SCENARIOS[scenario]
+    counter = Counter(count)
+    ubwa = BinanceWebSocketApiManager(
+        exchange="binance.com",
+        websocket_library=library,
+        websocket_base_uri=f"ws://127.0.0.1:{port}/",
+        output_default=output,
+        process_stream_data=counter,
+        warn_on_update=False,
+        disable_colorama=True,
+        # the local server never pings back -> disable keepalive noise
+        ping_interval_default=None,
+        ping_timeout_default=None,
+    )
+    cpu_start = time.process_time()
+    ubwa.create_stream(["bench"], [scenario])
+    finished = counter.done.wait(timeout=600)
+    cpu = time.process_time() - cpu_start
+    ubwa.stop_manager()
+    if not finished:
+        raise RuntimeError(
+            f"{library}/{scenario}: only {counter.count}/{count} messages"
+        )
+    wall = counter.last - counter.first
+    return {
+        "library": library,
+        "scenario": scenario,
+        "output": output,
+        "messages": counter.count,
+        "wall_s": wall,
+        "cpu_s": cpu,
+        "msgs_per_s": counter.count / wall,
+        "cpu_us_per_msg": cpu / counter.count * 1e6,
+    }
+
+
+def run_raw_library(library, scenario, port):
+    """Same replay without UBWA: the library's own receive loop."""
+    _, count = SCENARIOS[scenario]
+    if library == "picows":
+        from picows.websockets import connect
+    else:
+        from websockets import connect
+    uri = f"ws://127.0.0.1:{port}/stream?streams={scenario}@bench"
+
+    async def consume():
+        received = 0
+        first = None
+        async with connect(uri, ping_interval=None) as ws:
+            async for _ in ws:
+                if first is None:
+                    first = time.perf_counter()
+                received += 1
+                if received >= count:
+                    return received, time.perf_counter() - first
+
+    cpu_start = time.process_time()
+    received, wall = asyncio.run(consume())
+    cpu = time.process_time() - cpu_start
+    return {
+        "library": library,
+        "scenario": scenario,
+        "output": "raw library, no UBWA",
+        "messages": received,
+        "wall_s": wall,
+        "cpu_s": cpu,
+        "msgs_per_s": received / wall,
+        "cpu_us_per_msg": cpu / received * 1e6,
+    }
+
+
+def run_live(library, seconds, output):
+    """Live binance.com multiplex: rate is exchange-driven, compare CPU/msg."""
+    counter = Counter(target=sys.maxsize)
+    ubwa = BinanceWebSocketApiManager(
+        exchange="binance.com",
+        websocket_library=library,
+        output_default=output,
+        process_stream_data=counter,
+        warn_on_update=False,
+        disable_colorama=True,
+    )
+    markets = [
+        "btcusdt",
+        "ethusdt",
+        "bnbusdt",
+        "solusdt",
+        "xrpusdt",
+        "dogeusdt",
+        "adausdt",
+        "avaxusdt",
+        "linkusdt",
+        "dotusdt",
+        "maticusdt",
+        "ltcusdt",
+        "trxusdt",
+        "shibusdt",
+        "uniusdt",
+        "atomusdt",
+        "etcusdt",
+        "xlmusdt",
+        "nearusdt",
+        "aptusdt",
+    ]
+    ubwa.create_stream(
+        ["aggTrade", "trade", "bookTicker", "depth20@100ms", "kline_1m"], markets
+    )
+    ubwa.create_stream(["arr"], ["!ticker", "!miniTicker"])
+    ubwa.create_stream(["depth"], markets[:10])
+    # let all streams connect before measuring
+    time.sleep(10)
+    count0, bytes0 = counter.count, counter.bytes
+    cpu0 = time.process_time()
+    t0 = time.perf_counter()
+    time.sleep(seconds)
+    wall = time.perf_counter() - t0
+    cpu = time.process_time() - cpu0
+    messages = counter.count - count0
+    received_bytes = counter.bytes - bytes0
+    ubwa.stop_manager()
+    return {
+        "library": library,
+        "scenario": f"live_{seconds}s",
+        "output": output,
+        "messages": messages,
+        "wall_s": wall,
+        "cpu_s": cpu,
+        "msgs_per_s": messages / wall,
+        "cpu_us_per_msg": cpu / max(messages, 1) * 1e6,
+        "mb_per_s": received_bytes / wall / 1e6,
+        "cpu_pct": cpu / wall * 100,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+def median_of(results, key):
+    return statistics.median(r[key] for r in results)
+
+
+def report_local(all_results, output, title="Local replay"):
+    lines = []
+    lines.append(f"### {title} (`{output}`, median of repeats)")
+    lines.append("")
+    lines.append(
+        "| Scenario | ~msg size | msgs | websockets msgs/s | picows msgs/s | picows speedup | websockets CPU µs/msg | picows CPU µs/msg |"
+    )
+    lines.append("|---|---|---|---|---|---|---|---|")
+    for scenario in SCENARIOS:
+        rows = {
+            lib: [
+                r
+                for r in all_results
+                if r["library"] == lib and r["scenario"] == scenario
+            ]
+            for lib in LIBRARIES
+        }
+        if not all(rows.values()):
+            continue
+        pool = build_pool(scenario)
+        size = statistics.median(len(m) for m in pool)
+        ws_rate = median_of(rows["websockets"], "msgs_per_s")
+        pw_rate = median_of(rows["picows"], "msgs_per_s")
+        ws_cpu = median_of(rows["websockets"], "cpu_us_per_msg")
+        pw_cpu = median_of(rows["picows"], "cpu_us_per_msg")
+        lines.append(
+            f"| {scenario} | {size/1024:.1f} KB | {SCENARIOS[scenario][1]:,} | {ws_rate:,.0f} | {pw_rate:,.0f} | "
+            f"{pw_rate/ws_rate:.2f}x | {ws_cpu:.1f} | {pw_cpu:.1f} |"
+        )
+    return "\n".join(lines)
+
+
+def report_live(results, output):
+    lines = [f"### Live binance.com multiplex (`output_default='{output}'`)", ""]
+    lines.append("| Library | msgs/s | MB/s | CPU % of one core | CPU µs/msg |")
+    lines.append("|---|---|---|---|---|")
+    for r in results:
+        lines.append(
+            f"| {r['library']} | {r['msgs_per_s']:,.0f} | {r['mb_per_s']:.2f} | {r['cpu_pct']:.1f} | {r['cpu_us_per_msg']:.1f} |"
+        )
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--output", default="raw_data", choices=["raw_data", "dict"])
+    parser.add_argument("--repeat", type=int, default=3)
+    parser.add_argument("--scenarios", nargs="*", default=list(SCENARIOS))
+    parser.add_argument("--live", type=int, default=0, metavar="SECONDS")
+    parser.add_argument(
+        "--raw-libs",
+        action="store_true",
+        help="drive the libraries directly, without UBWA",
+    )
+    parser.add_argument("--markdown", metavar="FILE", help="append the report to FILE")
+    parser.add_argument("--port", type=int, default=PORT)
+    args = parser.parse_args()
+
+    import platform, websockets, picows
+    from unicorn_binance_websocket_api.manager import __version__ as ubwa_version
+
+    header = (
+        f"Python {platform.python_version()} on {platform.system()} {platform.machine()}, "
+        f"websockets {websockets.__version__}, picows {picows.__version__}, "
+        f"UBWA {ubwa_version}"
+    )
+    print(header)
+    reports = [header, ""]
+
+    if args.live:
+        live_results = []
+        for library in LIBRARIES:
+            print(f"live {library} for {args.live}s ...", flush=True)
+            r = run_live(library, args.live, args.output)
+            print(
+                f"  {r['messages']} msgs, {r['msgs_per_s']:.0f} msgs/s, CPU {r['cpu_pct']:.1f}%, {r['cpu_us_per_msg']:.1f} µs/msg"
+            )
+            live_results.append(r)
+        reports.append(report_live(live_results, args.output))
+    else:
+        ready = multiprocessing.Event()
+        server = multiprocessing.Process(
+            target=server_process, args=(args.port, ready), daemon=True
+        )
+        server.start()
+        ready.wait(10)
+        all_results = []
+        try:
+            for scenario in args.scenarios:
+                for repeat in range(args.repeat):
+                    # alternate libraries within a repeat to spread thermal/scheduling drift
+                    for library in (
+                        LIBRARIES if repeat % 2 == 0 else reversed(LIBRARIES)
+                    ):
+                        if args.raw_libs:
+                            r = run_raw_library(library, scenario, args.port)
+                        else:
+                            r = run_local(library, scenario, args.output, args.port)
+                        all_results.append(r)
+                        print(
+                            f"{scenario:18s} {library:10s} run {repeat+1}: {r['msgs_per_s']:>10,.0f} msgs/s  "
+                            f"{r['cpu_us_per_msg']:6.1f} µs CPU/msg  wall {r['wall_s']:.2f}s",
+                            flush=True,
+                        )
+        finally:
+            server.terminate()
+        if args.raw_libs:
+            reports.append(
+                report_local(
+                    all_results,
+                    "raw library, no UBWA",
+                    title="Local replay, libraries only",
+                )
+            )
+        else:
+            reports.append(report_local(all_results, f"output_default='{args.output}'"))
+
+    report = "\n".join(reports)
+    print("\n" + report)
+    if args.markdown:
+        with open(args.markdown, "a") as f:
+            f.write(report + "\n\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/llms.txt
+++ b/llms.txt
@@ -142,6 +142,7 @@ stream2 = ubwa.create_stream(channels="!userData", markets="arr",
 | output_default | str | "raw_data" | "raw_data", "dict", or "UnicornFy" |
 | high_performance | bool | False | Disable internal logging for speed |
 | socks5_proxy_server | str | None | SOCKS5 proxy address:port |
+| websocket_library | str | "websockets" | WebSocket client library: "websockets" or "picows" (optional extra `pip install unicorn-binance-websocket-api[picows]`, fails loud if missing) |
 
 ### create_stream()
 | Parameter | Type | Default | Purpose |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ unicorn-fy = ">=0.17.2"
 unicorn-binance-rest-api = ">=2.12.0"
 websocket-client = "*"
 websockets = ">=14.0"
+picows = { version = ">=2.1.0", optional = true }
+
+[tool.poetry.extras]
+picows = ["picows"]
 
 [tool.poetry.dev-dependencies]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ unicorn-fy>=0.17.2
 unicorn-binance-rest-api>=2.12.0
 websocket-client
 websockets>=14.0
+# Optional (extra `picows`): alternative WebSocket client library, select with
+# BinanceWebSocketApiManager(websocket_library="picows")
+# picows>=2.1.0

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,10 @@ setup(
         "typing_extensions",
         "Cython",
     ],
+    extras_require={
+        # Optional alternative WebSocket client library, see README "WebSocket library"
+        "picows": ["picows>=2.1.0"],
+    },
     keywords="binance, asyncio, async, asynchronous, concurrent, websocket-api, webstream-api, "
     "binance-websocket, binance-webstream, webstream, websocket, api, binance-dex, "
     "binance-futures, binance-margin, binance-us",

--- a/unicorn_binance_websocket_api/connection.py
+++ b/unicorn_binance_websocket_api/connection.py
@@ -39,18 +39,17 @@
 # IN THE SOFTWARE.
 
 from .exceptions import *
+from .websocket_library import WEBSOCKET_LIBRARY_PICOWS, get_connect
 from urllib.parse import urlparse
 import asyncio
 import copy
 import logging
 import socks  # PySocks https://pypi.org/project/PySocks/
 import sys
-import websockets
 
 __logger__: logging.getLogger = logging.getLogger("unicorn_binance_websocket_api")
 
 logger = __logger__
-connect: websockets.connect = websockets.connect
 
 
 class BinanceWebSocketApiConnection(object):
@@ -76,6 +75,10 @@ class BinanceWebSocketApiConnection(object):
         self.markets = copy.deepcopy(markets)
         self.symbols = copy.deepcopy(symbols)
         self.websocket = None
+        self.websocket_library = self.manager.websocket_library
+        # `websockets.connect()` and `picows.websockets.connect()` share the same
+        # signature, see websocket_library.py
+        self.connect = get_connect(self.websocket_library)
         self.api = copy.deepcopy(self.manager.stream_list[self.stream_id]["api"])
         self.add_timeout = (
             True if "!userData" in f"{channels}{markets}" or self.api is True else False
@@ -142,16 +145,17 @@ class BinanceWebSocketApiConnection(object):
             self.manager.socks5_proxy_address is None
             or self.manager.socks5_proxy_port is None
         ):
-            self._conn = connect(
+            self._conn = self.connect(
                 str(uri),
                 ping_interval=self.ping_interval,
                 ping_timeout=self.ping_timeout,
                 close_timeout=self.close_timeout,
                 additional_headers={"User-Agent": str(self.manager.get_user_agent())},
+                **self._library_specific_connect_kwargs(),
             )
             logger.info(
                 f"BinanceWebSocketApiConnection.__aenter__({self.stream_id}, {self.channels}"
-                f", {self.markets}) - No proxy used!"
+                f", {self.markets}) - No proxy used! (websocket_library: {self.websocket_library})"
             )
         else:
             websocket_socks5_proxy = socks.socksocket()
@@ -189,7 +193,7 @@ class BinanceWebSocketApiConnection(object):
                 logger.critical(error_msg)
                 raise Socks5ProxyConnectionError(error_msg)
 
-            self._conn = connect(
+            self._conn = self.connect(
                 str(uri),
                 ssl=self.manager.websocket_ssl_context,
                 sock=websocket_socks5_proxy,
@@ -198,11 +202,13 @@ class BinanceWebSocketApiConnection(object):
                 ping_timeout=self.ping_timeout,
                 close_timeout=self.close_timeout,
                 additional_headers={"User-Agent": str(self.manager.get_user_agent())},
+                **self._library_specific_connect_kwargs(proxy_socket=True),
             )
             logger.info(
                 f'BinanceWebSocketApiConnection.__aenter__("{self.stream_id}, {self.channels}'
                 f', {self.markets}") - Using proxy: {self.manager.socks5_proxy_address} '
-                f"{self.manager.socks5_proxy_port} SSL: {self.manager.socks5_proxy_ssl_verification}"
+                f"{self.manager.socks5_proxy_port} SSL: {self.manager.socks5_proxy_ssl_verification} "
+                f"(websocket_library: {self.websocket_library})"
             )
         try:
             self.websocket = await self._conn.__aenter__()
@@ -210,6 +216,26 @@ class BinanceWebSocketApiConnection(object):
             self.manager.set_socket_is_ready(stream_id=self.stream_id)
             raise StreamIsRestarting(stream_id=self.stream_id, reason=f"timeout error")
         return self
+
+    def _library_specific_connect_kwargs(self, proxy_socket: bool = False) -> dict:
+        """
+        Extra `connect()` kwargs that only one of the libraries needs.
+
+        picows: `picows.websockets.connect()` appends its own `User-Agent`
+        header on top of `additional_headers` unless `user_agent_header` is
+        `None`, and its `proxy=True` default would pick up `wss_proxy`/
+        `https_proxy` environment variables. The SOCKS5 tunnel is already
+        established by PySocks on the pre-connected socket, so a second proxy
+        hop must be disabled explicitly in that case. `websockets` (>=14.0)
+        neither duplicates the header nor is passed a `proxy` kwarg (that
+        parameter only exists since websockets 15.0), so it gets nothing here.
+        """
+        if self.websocket_library == WEBSOCKET_LIBRARY_PICOWS:
+            kwargs = {"user_agent_header": None}
+            if proxy_socket is True:
+                kwargs["proxy"] = None
+            return kwargs
+        return {}
 
     async def __aexit__(self, *args, **kwargs):
         logger.debug(

--- a/unicorn_binance_websocket_api/manager.py
+++ b/unicorn_binance_websocket_api/manager.py
@@ -49,6 +49,14 @@ from .connection_settings import (
 from .exceptions import *
 from .restclient import BinanceWebSocketApiRestclient
 from .sockets import BinanceWebSocketApiSocket
+from .websocket_library import (
+    CONNECTION_CLOSED_EXCEPTIONS,
+    INVALID_MESSAGE_EXCEPTIONS,
+    INVALID_STATUS_EXCEPTIONS,
+    NEGOTIATION_ERROR_EXCEPTIONS,
+    get_websocket_library_version,
+    validate_websocket_library,
+)
 from .api.api import WsApi
 from unicorn_binance_rest_api import BinanceRestApiManager, BinanceAPIException
 from unicorn_fy.unicorn_fy import UnicornFy
@@ -75,7 +83,6 @@ import time
 import traceback
 import uuid
 import orjson
-import websockets
 
 __app_name__: str = "unicorn-binance-websocket-api"
 __version__: str = "2.15.2.dev"
@@ -218,6 +225,14 @@ class BinanceWebSocketApiManager(threading.Thread):
     :param socks5_proxy_ssl_verification: Set to `False` to disable SSL server verification. Default is `True`.
     :param ubra_manager: Provide a shared unicorn_binance_rest_api.manager instance
     :type ubra_manager: BinanceRestApiManager
+    :param websocket_library: The WebSocket client library to use for all streams of this manager instance.
+                              `"websockets"` (default) uses `websockets <https://websockets.readthedocs.io>`__,
+                              `"picows"` uses the `websockets`-compatible API of
+                              `picows <https://picows.readthedocs.io>`__ (`picows.websockets`), a Cython based
+                              implementation. `picows` is an optional dependency, install it with
+                              `pip install unicorn-binance-websocket-api[picows]`. Selecting `"picows"` without the
+                              package installed raises an `ImportError`, an unknown value raises a `ValueError`.
+    :type websocket_library: str
     """
 
     def __init__(
@@ -250,6 +265,7 @@ class BinanceWebSocketApiManager(threading.Thread):
         socks5_proxy_ssl_verification: bool = True,
         auto_data_cleanup_stopped_streams: bool = False,
         ubra_manager: BinanceRestApiManager = None,
+        websocket_library: Literal["websockets", "picows"] = "websockets",
     ):
         threading.Thread.__init__(self)
         self.name = __app_name__
@@ -268,7 +284,16 @@ class BinanceWebSocketApiManager(threading.Thread):
         if self.disable_colorama is not True:
             logger.info(f"Initiating `colorama_{colorama.__version__}`")
             colorama.init()
-        logger.info(f"Using `websockets_{websockets.__version__}`")
+        try:
+            self.websocket_library = validate_websocket_library(websocket_library)
+        except (ValueError, ImportError) as error_msg:
+            logger.critical(str(error_msg))
+            self.stop_manager()
+            raise
+        logger.info(
+            f"Using websocket_library `{self.websocket_library}_"
+            f"{get_websocket_library_version(self.websocket_library)}`"
+        )
         self.specific_process_asyncio_queue = {}
         self.specific_process_stream_data = {}
         self.specific_process_stream_data_async = {}
@@ -552,13 +577,13 @@ class BinanceWebSocketApiManager(threading.Thread):
                 self._stream_is_restarting(
                     stream_id=stream_id, error_msg=str(error_msg)
                 )
-            except websockets.ConnectionClosed as error_msg:
+            except CONNECTION_CLOSED_EXCEPTIONS as error_msg:
                 logger.debug(
                     f"BinanceWebSocketApiManager._run_socket(stream_id={stream_id}), channels="
                     f"{channels}), markets={markets}) - websockets.ConnectionClosed: {error_msg}"
                 )
                 self._stream_is_restarting(stream_id=stream_id, error_msg=error_msg)
-            except websockets.exceptions.InvalidStatus as error_msg:
+            except INVALID_STATUS_EXCEPTIONS as error_msg:
                 status_code = error_msg.response.status_code
                 logger.error(
                     f"BinanceWebSocketApiManager._run_socket(stream_id={stream_id}), channels="
@@ -577,7 +602,7 @@ class BinanceWebSocketApiManager(threading.Thread):
                     self._stream_is_restarting(
                         stream_id=stream_id, error_msg=str(error_msg)
                     )
-            except websockets.InvalidMessage as error_msg:
+            except INVALID_MESSAGE_EXCEPTIONS as error_msg:
                 logger.error(
                     f"BinanceWebSocketApiManager._run_socket(stream_id={stream_id}), channels="
                     f"{channels}), markets={markets}) - websockets.InvalidMessage: {error_msg}"
@@ -585,7 +610,7 @@ class BinanceWebSocketApiManager(threading.Thread):
                 self._stream_is_restarting(
                     stream_id=stream_id, error_msg=str(error_msg)
                 )
-            except websockets.NegotiationError as error_msg:
+            except NEGOTIATION_ERROR_EXCEPTIONS as error_msg:
                 logger.error(
                     f"BinanceWebSocketApiManager._run_socket(stream_id={stream_id}), channels="
                     f"{channels}), markets={markets}) - websockets.NegotiationError: {error_msg}"

--- a/unicorn_binance_websocket_api/websocket_library.py
+++ b/unicorn_binance_websocket_api/websocket_library.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ¯\_(ツ)_/¯
+#
+# File: unicorn_binance_websocket_api/websocket_library.py
+#
+# Part of ‘UNICORN Binance WebSocket API’
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api
+# PyPI: https://pypi.org/project/unicorn-binance-websocket-api
+#
+# License: MIT
+# https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/LICENSE
+#
+# Author: Oliver Zehentleitner
+#
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+#
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+from .exceptions import *
+
+"""
+Selection of the underlying WebSocket client library.
+
+UBWA talks to the WebSocket library exclusively through the `websockets`
+client API (`connect()`, `recv()`, `send()`, `close()` and the exception
+classes). `picows` ships a drop-in replacement of that API in its
+`picows.websockets` subpackage (picows >= 2.0.0), so supporting it is a
+matter of picking the right `connect()` and catching both exception
+families. This module is the single place where that choice is made.
+"""
+
+from typing import Callable, Optional, Tuple, Type
+import logging
+import websockets
+import websockets.exceptions
+
+try:
+    import picows
+    import picows.websockets as picows_websockets
+except ImportError:  # picows is an optional dependency
+    picows = None
+    picows_websockets = None
+
+__logger__: logging.getLogger = logging.getLogger("unicorn_binance_websocket_api")
+
+logger = __logger__
+
+WEBSOCKET_LIBRARY_WEBSOCKETS: str = "websockets"
+WEBSOCKET_LIBRARY_PICOWS: str = "picows"
+SUPPORTED_WEBSOCKET_LIBRARIES: Tuple[str, ...] = (
+    WEBSOCKET_LIBRARY_WEBSOCKETS,
+    WEBSOCKET_LIBRARY_PICOWS,
+)
+
+
+def _exception_tuple(name: str) -> Tuple[Type[BaseException], ...]:
+    """
+    Build a tuple with the `websockets` exception class of the given name plus
+    the `picows.websockets` equivalent if picows is installed. The picows
+    classes are NOT subclasses of the `websockets` ones, so both have to be
+    caught explicitly.
+    """
+    classes = [getattr(websockets.exceptions, name)]
+    if picows_websockets is not None:
+        classes.append(getattr(picows_websockets.exceptions, name))
+    return tuple(classes)
+
+
+CONNECTION_CLOSED_EXCEPTIONS = _exception_tuple("ConnectionClosed")
+INVALID_STATUS_EXCEPTIONS = _exception_tuple("InvalidStatus")
+INVALID_MESSAGE_EXCEPTIONS = _exception_tuple("InvalidMessage")
+NEGOTIATION_ERROR_EXCEPTIONS = _exception_tuple("NegotiationError")
+
+
+def is_picows_available() -> bool:
+    return picows_websockets is not None
+
+
+def validate_websocket_library(websocket_library: Optional[str]) -> str:
+    """
+    Validate the `websocket_library` value passed to the manager and return the
+    normalized name. Fails loud on unknown values and on `picows` without the
+    package installed - a silent fallback to `websockets` would hide a broken
+    deployment.
+
+    :raises ValueError: unknown library name
+    :raises ImportError: `picows` selected but not installed
+    """
+    if websocket_library is None:
+        return WEBSOCKET_LIBRARY_WEBSOCKETS
+    if websocket_library not in SUPPORTED_WEBSOCKET_LIBRARIES:
+        raise ValueError(
+            f"Unknown websocket_library '{websocket_library}'! Supported: "
+            f"{', '.join(SUPPORTED_WEBSOCKET_LIBRARIES)}"
+        )
+    if websocket_library == WEBSOCKET_LIBRARY_PICOWS and not is_picows_available():
+        raise ImportError(
+            "websocket_library='picows' requested, but the optional dependency "
+            "`picows` is not installed. Install it with: "
+            "pip install unicorn-binance-websocket-api[picows]"
+        )
+    return websocket_library
+
+
+def get_websocket_library_version(websocket_library: str) -> str:
+    if websocket_library == WEBSOCKET_LIBRARY_PICOWS:
+        return picows.__version__
+    return websockets.__version__
+
+
+def get_connect(websocket_library: str) -> Callable:
+    """
+    Return the `connect()` callable of the selected library. Both share the
+    same call signature and return an async context manager yielding a
+    connection object with `recv()`, `send()` and `close()`.
+    """
+    if websocket_library == WEBSOCKET_LIBRARY_PICOWS:
+        return picows_websockets.connect
+    return websockets.connect

--- a/unittest_binance_websocket_api.py
+++ b/unittest_binance_websocket_api.py
@@ -43,12 +43,13 @@ from unicorn_binance_websocket_api.restclient import BinanceWebSocketApiRestclie
 from unicorn_binance_rest_api import BinanceRestApiManager
 import asyncio
 import logging
+import orjson
 import unittest
 import os
 import platform
 import time
 import threading
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import tracemalloc
 
@@ -1690,6 +1691,141 @@ class TestRestclientUnknownExchangeIsHandled(unittest.TestCase):
     def test_delete_listen_key_returns_none_instead_of_raising(self):
         rc = self._make_restclient()
         self.assertEqual(rc.delete_listen_key(stream_id="id1"), (None, None))
+
+
+class TestWebSocketLibrary(unittest.TestCase):
+    """
+    `websocket_library` switch: `websockets` (default) vs. the optional `picows`
+    (`picows.websockets` compatibility API). The roundtrip test runs against a
+    local server so it is deterministic and works without internet access.
+    """
+
+    LOCAL_PORT = 18765
+    LOCAL_MESSAGES = 25
+
+    @classmethod
+    def setUpClass(cls):
+        print(f"\r\nTestWebSocketLibrary:")
+        import websockets
+
+        cls.server_ready = threading.Event()
+
+        async def handler(ws):
+            # Stay idle first: exercises UBWA's `asyncio.wait_for(recv(), 1)`
+            # timeout/cancel path before the first message arrives.
+            await asyncio.sleep(2)
+            for i in range(cls.LOCAL_MESSAGES):
+                await ws.send(
+                    f'{{"stream":"btcusdt@trade","data":{{"e":"trade","s":"BTCUSDT","t":{i}}}}}'
+                )
+
+            # Answer every client request (UBWA may queue a subscribe payload
+            # on `create_stream()`, the test adds one more explicitly). A
+            # heartbeat keeps data flowing: once a stream has subscriptions and
+            # more than 10 receives, UBWA awaits `recv()` without timeout, so
+            # `stop_stream()` only takes effect when the next message arrives.
+            async def heartbeat():
+                while True:
+                    await asyncio.sleep(0.5)
+                    await ws.send('{"heartbeat":true}')
+
+            heartbeat_task = asyncio.create_task(heartbeat())
+            try:
+                async for msg in ws:
+                    request_id = orjson.loads(msg)["id"]
+                    await ws.send(f'{{"result":null,"id":{request_id}}}')
+            except Exception:
+                pass
+            finally:
+                heartbeat_task.cancel()
+
+        async def serve():
+            async with websockets.serve(handler, "127.0.0.1", cls.LOCAL_PORT):
+                cls.server_ready.set()
+                await asyncio.Future()
+
+        cls.server_thread = threading.Thread(
+            target=lambda: asyncio.run(serve()), daemon=True
+        )
+        cls.server_thread.start()
+        cls.server_ready.wait(10)
+
+    def _roundtrip(self, websocket_library):
+        received = []
+        ubwa = BinanceWebSocketApiManager(
+            exchange="binance.com",
+            websocket_library=websocket_library,
+            websocket_base_uri=f"ws://127.0.0.1:{self.LOCAL_PORT}/",
+            output_default="dict",
+            process_stream_data=lambda data: received.append(data),
+            warn_on_update=False,
+            disable_colorama=True,
+        )
+        try:
+            self.assertEqual(ubwa.websocket_library, websocket_library)
+            stream_id = ubwa.create_stream(["trade"], ["btcusdt"])
+
+            def trades():
+                return [item for item in received if "data" in item]
+
+            deadline = time.time() + 20
+            while len(trades()) < self.LOCAL_MESSAGES and time.time() < deadline:
+                time.sleep(0.1)
+            self.assertEqual(len(trades()), self.LOCAL_MESSAGES)
+            self.assertEqual(trades()[0]["data"]["t"], 0)
+            results_before = len(ubwa.get_results_from_endpoints())
+            ubwa.subscribe_to_stream(stream_id, channels=["kline_1m"])
+            deadline = time.time() + 10
+            while (
+                len(ubwa.get_results_from_endpoints()) <= results_before
+                and time.time() < deadline
+            ):
+                time.sleep(0.1)
+            self.assertEqual(len(ubwa.get_results_from_endpoints()), results_before + 1)
+        finally:
+            ubwa.stop_manager()
+
+    def test_default_is_websockets(self):
+        print(f"test_default_is_websockets():")
+        with BinanceWebSocketApiManager(
+            exchange="binance.com", warn_on_update=False, disable_colorama=True
+        ) as ubwa:
+            self.assertEqual(ubwa.websocket_library, "websockets")
+
+    def test_unknown_library_raises(self):
+        print(f"test_unknown_library_raises():")
+        with self.assertRaises(ValueError):
+            BinanceWebSocketApiManager(
+                exchange="binance.com",
+                websocket_library="hyperws",
+                warn_on_update=False,
+                disable_colorama=True,
+            )
+
+    def test_picows_not_installed_raises(self):
+        print(f"test_picows_not_installed_raises():")
+        from unicorn_binance_websocket_api import websocket_library
+
+        with patch.object(websocket_library, "is_picows_available", return_value=False):
+            with self.assertRaises(ImportError):
+                BinanceWebSocketApiManager(
+                    exchange="binance.com",
+                    websocket_library="picows",
+                    warn_on_update=False,
+                    disable_colorama=True,
+                )
+
+    def test_roundtrip_websockets(self):
+        print(f"test_roundtrip_websockets():")
+        self._roundtrip("websockets")
+
+    def test_roundtrip_picows(self):
+        print(f"test_roundtrip_picows():")
+        from unicorn_binance_websocket_api import websocket_library
+
+        if not websocket_library.is_picows_available():
+            self.skipTest("picows is not installed")
+        self._roundtrip("picows")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Optional support for [picows](https://github.com/tarasko/picows) as WebSocket client library, selected per manager instance:

```python
ubwa = BinanceWebSocketApiManager(exchange="binance.com", websocket_library="picows")
```

Default stays `"websockets"`. picows is an optional extra (`pip install unicorn-binance-websocket-api[picows]`, picows >= 2.1.0, also on conda-forge).

## How

picows ships a drop-in replacement of the `websockets` client API (`picows.websockets`, since 2.0.0). UBWA only talks to the library through `connect()`, `recv()`, `send()`, `close()` and the exception classes, so:

- `websocket_library.py` (new): library selection, validation (fail loud: `ValueError` for unknown names, `ImportError` for `"picows"` without the package, no silent fallback) and the exception tuples the manager catches. The picows exception classes are **not** subclasses of the `websockets` ones, they only share names.
- `connection.py`: `connect()` comes from the selected library. picows gets `user_agent_header=None` (it would otherwise add a second `User-Agent` on top of `additional_headers`) and `proxy=None` on the SOCKS5 path (its `proxy=True` default reads `wss_proxy`/`https_proxy` env vars and would try a second hop over the PySocks tunnel).
- `manager.py`: new parameter, catches both exception families in `_run_socket()`.
- `sockets.py` untouched.

Verified locally for both libraries: stream data through the full stack, idle-timeout (`wait_for(recv())` cancel) path, subscribe/result roundtrip, server-side close → restart, SOCKS5 proxy + TLS (local SOCKS5 server, self-signed cert, `socks5_proxy_ssl_verification=False`).

## Tests

- `TestWebSocketLibrary` in the unittest file: default, invalid value, missing package (mocked), local-server roundtrip for `websockets` and `picows` (skips picows if not installed). CI installs picows so the picows path is actually exercised.
- `dev/test_websocket_library_benchmark.py` (not in CI): local replay through UBWA with message sizes 0.2 KB … 450 KB plus a multiplex mix, raw-library baseline (`--raw-libs`) and a live binance.com mode (`--live SECONDS`).

## Benchmark (Python 3.13, websockets 16.0, picows 2.1.3, x86_64, median of 3)

Through UBWA, `output_default="raw_data"`:

| Scenario | ~msg size | websockets msgs/s | picows msgs/s | speedup | websockets CPU µs/msg | picows CPU µs/msg |
|---|---|---|---|---|---|---|
| small_aggtrade | 0.2 KB | 116,314 | 163,406 | 1.40x | 8.7 | 6.2 |
| medium_kline | 0.3 KB | 112,815 | 158,541 | 1.41x | 9.0 | 6.4 |
| large_depth20 | 1.0 KB | 96,835 | 135,253 | 1.40x | 10.5 | 7.8 |
| xlarge_depth_diff | 9.1 KB | 50,746 | 51,629 | 1.02x | 20.2 | 20.0 |
| huge_ticker_arr | 454 KB | 1,753 | 1,597 | 0.91x | 615.9 | 676.9 |
| multiplex_mix | 0.2 KB | 110,738 | 153,079 | 1.38x | 9.2 | 6.7 |

- ≤ ~1 KB: picows ~1.4x throughput, ~30 % less CPU per message. ≥ ~10 KB: parity (within noise).
- Libraries driven directly without UBWA: 1.5x–2x apart (≈320k vs ≈490k msgs/s small messages). UBWA adds a constant ~5 µs/msg on top of either library, so the stream loop itself is the bigger lever.
- Live binance.com, 20 symbol multiplex (a few hundred msgs/s): no measurable difference, CPU is dominated by the manager's fixed overhead.

Full tables (`dict` output, raw-library baseline, live) and the reasoning for the compat-API route over a native picows listener implementation: `context/websocket-library.md`.

## Docs

README (new section "WebSocket library: `websockets` or `picows`"), llms.txt, AGENTS.md, CHANGELOG (2.15.2.dev), `context/websocket-library.md` + index.
