### PR TITLE
perf: slim down the stream loop hot path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,9 @@ Managed in `requirements.txt`, `setup.py`, and `pyproject.toml` — **all three 
 - `picows>=2.1.0` — **optional** (extra `picows`), alternative WebSocket library via its
   `websockets`-compatible API; selected with `BinanceWebSocketApiManager(websocket_library="picows")`,
   see [`context/websocket-library.md`](context/websocket-library.md). Benchmark:
-  `dev/test_websocket_library_benchmark.py`
+  `dev/test_websocket_library_benchmark.py`, profile of the stream thread:
+  `dev/profile_stream_loop.py` (per-message cost of the loop itself, see
+  [`context/stream-loop.md`](context/stream-loop.md))
 - `requests>=2.31.0` — HTTP
 - `orjson` — fast JSON serialization
 - `unicorn-fy>=0.15.0` — stream data normalization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,26 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   without the package raises `ImportError`, unknown values raise `ValueError`.
   Benchmark script and results: `dev/test_websocket_library_benchmark.py`,
   [`context/websocket-library.md`](context/websocket-library.md).
+  Discussion and user reports:
+  [issue #477](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/477).
+- `dev/profile_stream_loop.py`: cProfile of a stream thread against the local
+  replay server, to see where UBWA's own per-message time goes.
+### Changed
+- Stream loop hot path slimmed down (per received message): removed 18
+  `logger.debug()` f-string calls that were evaluated with debug logging off,
+  5 of 7 lock cycles (per-stream counters have a single writer, the stream's
+  own thread; the lock is kept only for inserting a new per-second key,
+  because `_frequent_checks()` deep-copies those dicts), and the duplicated
+  `set_heartbeat()` / stop- and crash-request checks in
+  `BinanceWebSocketApiConnection.receive()` that the loop in
+  `start_socket()` already performs. Measured through the full stack with
+  0.2 KB messages: `websockets` 116,314 -> 201,912 msgs/s, `picows`
+  163,406 -> 403,316 msgs/s, all statistics preserved. Details and
+  ablation: [`context/stream-loop.md`](context/stream-loop.md).
+- Received-bytes statistics (`total_received_bytes`,
+  `transfer_rate_per_second`) now count the payload size (`len()` of the
+  received JSON text) instead of `sys.getsizeof(str(...))`, which included
+  the Python object header (~49 bytes per message too many).
 
 ## 2.15.2
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -531,6 +531,9 @@ Selecting `"picows"` without the package installed raises an `ImportError`, an u
 there is no silent fallback. SOCKS5 proxies work with both libraries. The [conda-forge](https://anaconda.org/conda-forge/picows)
 package is `picows`.
 
+Questions, experiences and your own benchmark numbers:
+[issue #477 - WebSocket library: websockets vs. picows](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/477).
+
 #### Is `picows` faster? Measured, not assumed
 `dev/test_websocket_library_benchmark.py` replays Binance shaped messages from a local server (separate process)
 through the complete UBWA stack (connection → stream loop → `process_stream_data` callback), 3 runs, median.
@@ -538,24 +541,24 @@ Python 3.13, websockets 16.0, picows 2.1.3, x86_64 Linux, `output_default="raw_d
 
 | Scenario | ~msg size | msgs | websockets msgs/s | picows msgs/s | picows speedup | websockets CPU µs/msg | picows CPU µs/msg |
 |---|---|---|---|---|---|---|---|
-| small_aggtrade | 0.2 KB | 300,000 | 116,314 | 163,406 | 1.40x | 8.7 | 6.2 |
-| medium_kline | 0.3 KB | 150,000 | 112,815 | 158,541 | 1.41x | 9.0 | 6.4 |
-| large_depth20 | 1.0 KB | 60,000 | 96,835 | 135,253 | 1.40x | 10.5 | 7.8 |
-| xlarge_depth_diff | 9.1 KB | 30,000 | 50,746 | 51,629 | 1.02x | 20.2 | 20.0 |
-| huge_ticker_arr | 453.9 KB | 600 | 1,753 | 1,597 | 0.91x | 615.9 | 676.9 |
-| multiplex_mix | 0.2 KB | 120,000 | 110,738 | 153,079 | 1.38x | 9.2 | 6.7 |
+| small_aggtrade | 0.2 KB | 300,000 | 201,912 | 403,316 | 2.00x | 5.1 | 2.5 |
+| medium_kline | 0.3 KB | 150,000 | 195,460 | 371,019 | 1.90x | 5.2 | 2.9 |
+| large_depth20 | 1.0 KB | 60,000 | 153,187 | 259,960 | 1.70x | 6.8 | 4.1 |
+| xlarge_depth_diff | 9.1 KB | 30,000 | 64,172 | 67,972 | 1.06x | 16.3 | 15.4 |
+| huge_ticker_arr | 453.9 KB | 600 | 1,768 | 1,662 | 0.94x | 608.7 | 641.0 |
+| multiplex_mix | 0.2 KB | 120,000 | 180,406 | 334,188 | 1.85x | 5.7 | 3.2 |
 
-- Up to ~1 KB per message (aggTrade, kline, bookTicker, depth20, ...) picows delivers **~1.4x** the throughput and
-  needs ~30 % less CPU per message. From ~10 KB upwards (full `depth` diffs, `!ticker@arr`) both are on par - the
-  cost there is UTF-8 decoding and UBWA's own per-message work, not the WebSocket framing.
-- Driven directly, without UBWA, the libraries are 1.5x-2x apart (websockets ~320k msgs/s vs. picows ~490k msgs/s
-  for small messages). UBWA's stream loop adds a constant ~5 µs per message on top of either library, which is why
-  the gap shrinks inside UBWA.
+- Up to ~1 KB per message (aggTrade, kline, bookTicker, depth20, ...) picows delivers **1.7x-2x** the throughput at
+  about half the CPU per message. From ~10 KB upwards (full `depth` diffs, `!ticker@arr`) both are on par - the
+  cost there is UTF-8 decoding and JSON handling, not the WebSocket framing.
+- With `output_default="dict"` (orjson parsing included) the gap is 1.4x-1.7x for messages up to 1 KB.
 - Against live binance.com with a 20 symbol multiplex (a few hundred msgs/s) the choice makes no measurable
   difference: the CPU load is dominated by UBWA's fixed per-manager overhead, not by the transport.
 - So: pick `picows` for high-throughput consumers (many streams, `depth@100ms` on hundreds of symbols, CPU-bound
-  hosts), stay on `websockets` if you need its broader ecosystem. Full tables including `output_default="dict"`
-  and the raw-library baseline: [`context/websocket-library.md`](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/blob/master/context/websocket-library.md).
+  hosts), stay on `websockets` if you need the default, its broader ecosystem or PyPy. Full tables including the
+  raw-library baseline and the live run: [`context/websocket-library.md`](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/blob/master/context/websocket-library.md);
+  what UBWA itself costs per message and how that was cut:
+  [`context/stream-loop.md`](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/blob/master/context/stream-loop.md).
 
 ### From source of the latest release with PIP from [GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api)
 #### Linux, macOS, ...

--- a/context/index.md
+++ b/context/index.md
@@ -62,7 +62,7 @@
 
 ## S
 
-- [stream-loop.md](stream-loop.md) — untimed `recv()` after the first receives (deliberate, `wait_for` overhead; stop latency on idle streams accepted) and the profiled breakdown of UBWA's own ~5 µs per message (debug f-strings, locks, duplicate checks) with ablation numbers
+- [stream-loop.md](stream-loop.md) — untimed `recv()` after the first receives (deliberate, `wait_for` overhead; stop latency on idle streams accepted) and the profiled ~5 µs per message UBWA used to add (debug f-strings, locks, duplicate checks), the ablation, and the hot-path slim-down that removed most of it
 
 ## T
 

--- a/context/index.md
+++ b/context/index.md
@@ -62,7 +62,7 @@
 
 ## S
 
-- [stream-loop.md](stream-loop.md) — untimed `recv()` after the first receives (deliberate, `wait_for` overhead; stop latency on idle streams accepted) and where UBWA's own per-message cost sits
+- [stream-loop.md](stream-loop.md) — untimed `recv()` after the first receives (deliberate, `wait_for` overhead; stop latency on idle streams accepted) and the profiled breakdown of UBWA's own ~5 µs per message (debug f-strings, locks, duplicate checks) with ablation numbers
 
 ## T
 

--- a/context/stream-loop.md
+++ b/context/stream-loop.md
@@ -35,7 +35,7 @@ because of the per-message overhead. Closing the websocket from
 
 ## Per-message work in the loop that is not the transport - profiled
 
-**Type:** constraint
+**Type:** decision
 **Status:** active
 **Evidence:** confirmed
 **Source:** profiling pass 2026-09-10: cProfile of the stream thread (300k aggTrade messages from the local replay server, picows) plus a cumulative ablation with lean replacements of the hot-path methods, both libraries, median of 3; benchmark harness `dev/test_websocket_library_benchmark.py`
@@ -84,7 +84,35 @@ thread deep-copies the dict can raise "dictionary changed size during
 iteration", so the insert path must keep the lock. That is the split the
 ablation's stage C did not yet make - the production change must.
 
-**Status of the change:** measured and proposed, not implemented; the
-maintainer decides which stages to take (the debug-log removal touches
-logs that may have been kept for lock debugging; `len()` changes the
-reported byte statistics to payload size).
+**Implemented** (same day, all four stages, PR "perf: slim down the stream
+loop hot path"): the 18 debug f-strings in the hot path are gone (the
+`lock entered/leaving` pairs and the per-call entry logs; `send()` and the
+non-hot-path logs are untouched), the per-stream counters take
+`stream_list_lock` only on the once-per-second key insert, `receive()` no
+longer duplicates heartbeat and stop/crash checks, byte statistics use
+`len()` of the payload. Result through the full stack, `raw_data`, median
+of 3, same machine:
+
+| Scenario | ~msg size | msgs | websockets msgs/s | picows msgs/s | picows speedup | websockets CPU µs/msg | picows CPU µs/msg |
+|---|---|---|---|---|---|---|---|
+| small_aggtrade | 0.2 KB | 300,000 | 201,912 | 403,316 | 2.00x | 5.1 | 2.5 |
+| medium_kline | 0.3 KB | 150,000 | 195,460 | 371,019 | 1.90x | 5.2 | 2.9 |
+| large_depth20 | 1.0 KB | 60,000 | 153,187 | 259,960 | 1.70x | 6.8 | 4.1 |
+| xlarge_depth_diff | 9.1 KB | 30,000 | 64,172 | 67,972 | 1.06x | 16.3 | 15.4 |
+| huge_ticker_arr | 453.9 KB | 600 | 1,768 | 1,662 | 0.94x | 608.7 | 641.0 |
+| multiplex_mix | 0.2 KB | 120,000 | 180,406 | 334,188 | 1.85x | 5.7 | 3.2 |
+
+Compared with the pre-optimization table in `websocket-library.md`:
+websockets 116k -> 202k msgs/s (1.7x), picows 163k -> 403k msgs/s (2.5x) at
+0.2 KB. picows now sits at ~2.5 µs/msg against ~2.0 µs for the raw library.
+
+**Rejected alternative for the debug logs:** keeping them behind an
+`if self.debug:` guard. Rejected because the removed lines carried no
+information (`lock was entered` / `Leaving lock`, entry of a getter), and
+even a guarded call costs ~0.05 µs x 18 per message. Logs that report an
+event or an error stay.
+
+**Revisit when:** a second writer for `last_heartbeat`,
+`processed_receives_total` or the per-second dicts is introduced - then the
+lock-free increments in `set_heartbeat()`, `increase_received_bytes_per_second()`
+and `increase_processed_receives_statistic()` need the lock back.

--- a/context/stream-loop.md
+++ b/context/stream-loop.md
@@ -33,19 +33,58 @@ idle stream is acceptable to the maintainer; not a bug.
 because of the per-message overhead. Closing the websocket from
 `stop_stream()` directly was not in contention.
 
-## Per-message work in the loop that is not the transport
+## Per-message work in the loop that is not the transport - profiled
 
 **Type:** constraint
 **Status:** active
-**Evidence:** inferred
-**Source:** `websocket-library.md` "Benchmark results"; code reading of `connection.py` / `sockets.py`
+**Evidence:** confirmed
+**Source:** profiling pass 2026-09-10: cProfile of the stream thread (300k aggTrade messages from the local replay server, picows) plus a cumulative ablation with lean replacements of the hot-path methods, both libraries, median of 3; benchmark harness `dev/test_websocket_library_benchmark.py`
 
-The benchmark for the websocket-library switch showed a constant ~5 µs per
-message that UBWA spends on top of either library (raw libraries 2-3 µs/msg,
-through UBWA 6-9 µs/msg). Not profiled yet; visible per-message work in the
-code: `sys.getsizeof(str(...))` byte accounting plus three lock-protected
-counters in `receive()`, the `wait_for()` wrapper on early receives,
-substring checks (`"error" in`, `"result" in`, `userdata_subscribe_id in`)
-over the raw JSON string, and the dispatch cascade in `start_socket()`.
-Recorded so that a future optimization pass starts from the measurement
-rather than from the transport.
+The websocket-library benchmark showed a constant ~5 µs per message that
+UBWA spends on top of either library (raw libraries 2-3 µs/msg, through UBWA
+6-9 µs/msg). Profiling attributes it as follows, per received message:
+
+- **18 `logger.debug(f"...")` calls** while debug logging is off. The
+  f-string is built before `debug()` checks the level, ~0.1 µs each. 12 of
+  them are `stream_list_lock was entered` / `Leaving stream_list_lock` pairs
+  inside `set_heartbeat()`, `increase_received_bytes_per_second()` and
+  `increase_processed_receives_statistic()`; the rest are entry logs of
+  `receive()`, `is_stop_request()`, `is_crash_request()` (each with a
+  `get_debug_log()` call) and the dispatch log in `start_socket()`.
+- **7 lock acquire/release cycles** (`stream_list_lock` x5,
+  `total_received_bytes_lock`, `total_receives_lock`), ~0.17 µs each.
+- **Duplicate work:** `set_heartbeat()` runs twice per message (in
+  `receive()` and at the top of the loop iteration), `is_stop_request()` and
+  `is_crash_request()` twice (loop condition and `raise_exceptions()` inside
+  `receive()`).
+- `sys.getsizeof(str(msg))` for the byte statistics (~0.1 µs, and it counts
+  the str object header, not the payload).
+
+**Ablation, small messages (0.2 KB), through the full stack, `raw_data`:**
+
+| Stage (cumulative) | websockets msgs/s | CPU µs/msg | picows msgs/s | CPU µs/msg |
+|---|---|---|---|---|
+| A baseline | 119,880 | 8.41 | 166,906 | 6.07 |
+| B no debug f-strings in the hot path | 160,992 | 6.28 | 268,185 | 3.82 |
+| C + per-stream counters without `stream_list_lock` | 181,873 | 5.57 | 306,244 | 3.34 |
+| D + heartbeat/stop/crash once per iteration | 181,969 | 5.56 | 344,516 | 2.93 |
+| E + `len()` instead of `sys.getsizeof(str())` | 191,839 | 5.30 | 370,564 | 2.76 |
+
+Raw libraries for reference: websockets ~3.0 µs, picows ~2.0 µs. Stage E
+leaves ~0.8 µs of UBWA overhead with picows (dispatch cascade, one debug
+call, counters) and ~2.3 µs with websockets.
+
+**Lock-free counters, why it is safe and where it is not:** the per-stream
+fields (`last_heartbeat`, `processed_receives_total`, the per-second
+dicts) have a single writer, the stream's own thread; `_frequent_checks()`
+in the manager thread reads them and prunes old timestamp keys after
+`copy.deepcopy()` under the lock. A lock-free `+=` on an *existing* key is
+safe; *inserting* a new timestamp key (once per second) while the manager
+thread deep-copies the dict can raise "dictionary changed size during
+iteration", so the insert path must keep the lock. That is the split the
+ablation's stage C did not yet make - the production change must.
+
+**Status of the change:** measured and proposed, not implemented; the
+maintainer decides which stages to take (the debug-log removal touches
+logs that may have been kept for lock debugging; `len()` changes the
+reported byte statistics to payload size).

--- a/context/websocket-library.md
+++ b/context/websocket-library.md
@@ -149,7 +149,7 @@ excluded. 3 runs each, median.
 | huge_ticker_arr | 453.9 KB | 600 | 5,842 | 6,698 | 1.15x | 172.5 | 140.7 |
 | multiplex_mix | 0.2 KB | 120,000 | 304,762 | 470,529 | 1.54x | 3.3 | 2.1 |
 
-**Through UBWA, `output_default="raw_data"` (callback receives the JSON string):**
+**Through UBWA, `output_default="raw_data"` (callback receives the JSON string) - before the stream-loop optimization (see `stream-loop.md`):**
 
 | Scenario | ~msg size | msgs | websockets msgs/s | picows msgs/s | picows speedup | websockets CPU µs/msg | picows CPU µs/msg |
 |---|---|---|---|---|---|---|---|
@@ -160,7 +160,7 @@ excluded. 3 runs each, median.
 | huge_ticker_arr | 453.9 KB | 600 | 1,753 | 1,597 | 0.91x | 615.9 | 676.9 |
 | multiplex_mix | 0.2 KB | 120,000 | 110,738 | 153,079 | 1.38x | 9.2 | 6.7 |
 
-**Through UBWA, `output_default="dict"` (plus `orjson.loads()`):**
+**Through UBWA, `output_default="dict"` (plus `orjson.loads()`) - before the stream-loop optimization:**
 
 | Scenario | ~msg size | msgs | websockets msgs/s | picows msgs/s | picows speedup | websockets CPU µs/msg | picows CPU µs/msg |
 |---|---|---|---|---|---|---|---|
@@ -170,6 +170,28 @@ excluded. 3 runs each, median.
 | xlarge_depth_diff | 9.1 KB | 30,000 | 22,118 | 23,302 | 1.05x | 46.1 | 43.2 |
 | huge_ticker_arr | 453.9 KB | 600 | 357 | 397 | 1.11x | 2871.3 | 2617.6 |
 | multiplex_mix | 0.2 KB | 120,000 | 86,168 | 113,088 | 1.31x | 11.8 | 9.0 |
+
+**Through UBWA, `output_default="raw_data"` - after the stream-loop optimization (same day, same machine):**
+
+| Scenario | ~msg size | msgs | websockets msgs/s | picows msgs/s | picows speedup | websockets CPU µs/msg | picows CPU µs/msg |
+|---|---|---|---|---|---|---|---|
+| small_aggtrade | 0.2 KB | 300,000 | 201,912 | 403,316 | 2.00x | 5.1 | 2.5 |
+| medium_kline | 0.3 KB | 150,000 | 195,460 | 371,019 | 1.90x | 5.2 | 2.9 |
+| large_depth20 | 1.0 KB | 60,000 | 153,187 | 259,960 | 1.70x | 6.8 | 4.1 |
+| xlarge_depth_diff | 9.1 KB | 30,000 | 64,172 | 67,972 | 1.06x | 16.3 | 15.4 |
+| huge_ticker_arr | 453.9 KB | 600 | 1,768 | 1,662 | 0.94x | 608.7 | 641.0 |
+| multiplex_mix | 0.2 KB | 120,000 | 180,406 | 334,188 | 1.85x | 5.7 | 3.2 |
+
+**Through UBWA, `output_default="dict"` - after the stream-loop optimization:**
+
+| Scenario | ~msg size | msgs | websockets msgs/s | picows msgs/s | picows speedup | websockets CPU µs/msg | picows CPU µs/msg |
+|---|---|---|---|---|---|---|---|
+| small_aggtrade | 0.2 KB | 300,000 | 172,638 | 296,252 | 1.72x | 5.9 | 3.4 |
+| medium_kline | 0.3 KB | 150,000 | 153,152 | 248,954 | 1.63x | 6.7 | 4.1 |
+| large_depth20 | 1.0 KB | 60,000 | 108,547 | 152,108 | 1.40x | 9.6 | 7.0 |
+| xlarge_depth_diff | 9.1 KB | 30,000 | 24,308 | 25,582 | 1.05x | 42.0 | 39.4 |
+| huge_ticker_arr | 453.9 KB | 600 | 394 | 421 | 1.07x | 2572.1 | 2465.9 |
+| multiplex_mix | 0.2 KB | 120,000 | 134,163 | 202,423 | 1.51x | 7.7 | 5.1 |
 
 **Live binance.com, 20 symbol multiplex + `!ticker@arr`/`!miniTicker@arr` + 10x `depth`, 60 s each, sequential:**
 
@@ -188,10 +210,11 @@ excluded. 3 runs each, median.
   the payload plus UBWA's substring checks (`"error" in ...`,
   `"result" in ...`) over the whole message dominate, and both libraries pay
   the same for that.
-- UBWA adds a constant ~5 µs per message on top of either library
-  (3.1 -> 8.7 µs for websockets, 2.0 -> 6.2 µs for picows). That is the
-  bigger lever: the transport is at most a third of the per-message cost.
-  Where those ~5 µs go has not been profiled; candidates in `stream-loop.md`.
+- Before the stream-loop optimization UBWA added a constant ~5 µs per
+  message on top of either library (3.1 -> 8.7 µs for websockets,
+  2.0 -> 6.2 µs for picows). After it (`stream-loop.md`) the overhead is
+  ~0.5 µs with picows and ~2 µs with websockets, and the picows advantage
+  inside UBWA grew from 1.4x to 1.7x-2x for messages up to 1 KB.
 - Live at a few hundred msgs/s the numbers are identical (~198 µs CPU/msg for
   both) because the manager's fixed overhead (monitoring loops, per-stream
   event loops, keepalive) dominates; message rate differs between the two

--- a/dev/profile_stream_loop.py
+++ b/dev/profile_stream_loop.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# File: dev/profile_stream_loop.py
+#
+# Part of ‘UNICORN Binance WebSocket API’
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api
+# PyPI: https://pypi.org/project/unicorn-binance-websocket-api
+#
+# Author: Oliver Zehentleitner
+#
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""
+cProfile the UBWA stream thread while it receives one benchmark scenario from
+the local replay server of `dev/test_websocket_library_benchmark.py`.
+
+Shows where UBWA's own per-message time goes (on top of the WebSocket
+library). Not part of CI. Numbers under cProfile are inflated (~3x), the
+call counts and the relative distribution are what matters; use the
+benchmark script for absolute numbers.
+
+Usage:
+    python3 dev/profile_stream_loop.py [websockets|picows] [scenario] [raw_data|dict]
+    python3 dev/profile_stream_loop.py picows small_aggtrade raw_data
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import test_websocket_library_benchmark as bench  # noqa: E402
+from unicorn_binance_websocket_api.manager import (  # noqa: E402
+    BinanceWebSocketApiManager,
+)
+import cProfile  # noqa: E402
+import io  # noqa: E402
+import multiprocessing  # noqa: E402
+import pstats  # noqa: E402
+import threading  # noqa: E402
+import time  # noqa: E402
+
+PORT = 18773
+
+
+def main():
+    library = sys.argv[1] if len(sys.argv) > 1 else "picows"
+    scenario = sys.argv[2] if len(sys.argv) > 2 else "small_aggtrade"
+    output = sys.argv[3] if len(sys.argv) > 3 else "raw_data"
+
+    ready = multiprocessing.Event()
+    server = multiprocessing.Process(
+        target=bench.server_process, args=(PORT, ready), daemon=True
+    )
+    server.start()
+    ready.wait(10)
+
+    profiles = {}
+    original = BinanceWebSocketApiManager._create_stream_thread
+
+    def profiled(self, *args, **kwargs):
+        profiler = cProfile.Profile()
+        profiler.enable()
+        try:
+            return original(self, *args, **kwargs)
+        finally:
+            profiler.disable()
+            profiles[threading.current_thread().name] = profiler
+
+    BinanceWebSocketApiManager._create_stream_thread = profiled
+
+    _, count = bench.SCENARIOS[scenario]
+    counter = bench.Counter(count)
+    ubwa = BinanceWebSocketApiManager(
+        exchange="binance.com",
+        websocket_library=library,
+        websocket_base_uri=f"ws://127.0.0.1:{PORT}/",
+        output_default=output,
+        process_stream_data=counter,
+        warn_on_update=False,
+        disable_colorama=True,
+        ping_interval_default=None,
+        ping_timeout_default=None,
+    )
+    ubwa.create_stream(["bench"], [scenario])
+    counter.done.wait(120)
+    wall = counter.last - counter.first
+    ubwa.stop_manager()
+    # The server close ends the untimed recv() of the stream thread, see
+    # context/stream-loop.md
+    server.terminate()
+    for _ in range(100):
+        if profiles:
+            break
+        time.sleep(0.1)
+
+    out = io.StringIO()
+    stats = pstats.Stats(list(profiles.values())[0], stream=out)
+    stats.sort_stats("tottime").print_stats(30)
+    print(f"{library} {scenario} {output}: {count / wall:,.0f} msgs/s under cProfile")
+    print(out.getvalue())
+
+
+if __name__ == "__main__":
+    main()

--- a/llms.txt
+++ b/llms.txt
@@ -142,7 +142,7 @@ stream2 = ubwa.create_stream(channels="!userData", markets="arr",
 | output_default | str | "raw_data" | "raw_data", "dict", or "UnicornFy" |
 | high_performance | bool | False | Disable internal logging for speed |
 | socks5_proxy_server | str | None | SOCKS5 proxy address:port |
-| websocket_library | str | "websockets" | WebSocket client library: "websockets" or "picows" (optional extra `pip install unicorn-binance-websocket-api[picows]`, fails loud if missing) |
+| websocket_library | str | "websockets" | WebSocket client library: "websockets" or "picows" (optional extra `pip install unicorn-binance-websocket-api[picows]`, fails loud if missing; picows ~1.4x+ throughput for messages up to ~1 KB, see https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/477) |
 
 ### create_stream()
 | Parameter | Type | Default | Purpose |

--- a/unicorn_binance_websocket_api/connection.py
+++ b/unicorn_binance_websocket_api/connection.py
@@ -250,8 +250,10 @@ class BinanceWebSocketApiConnection(object):
         return await self.websocket.close()
 
     async def receive(self):
-        logger.debug(f"BinanceWebSocketApiConnection.receive({str(self.stream_id)})")
-        self.raise_exceptions()
+        # Hot path, once per received message. No per-call debug log, no
+        # `raise_exceptions()` and no `set_heartbeat()` here: the loop in
+        # `BinanceWebSocketApiSocket.start_socket()` does both right before
+        # calling this. See context/stream-loop.md for the measurements.
         if self.add_timeout:
             if self.api is True:
                 timeout = 0.1
@@ -275,8 +277,9 @@ class BinanceWebSocketApiConnection(object):
                 received_data_json = await asyncio.wait_for(
                     self.websocket.recv(), timeout=1
                 )
-        self.manager.set_heartbeat(self.stream_id)
-        size = sys.getsizeof(str(received_data_json))
+        # Payload size (characters of the JSON text = bytes for Binance's ASCII
+        # JSON), not `sys.getsizeof()` of the Python object.
+        size = len(received_data_json)
         self.manager.add_total_received_bytes(size)
         self.manager.increase_received_bytes_per_second(self.stream_id, size)
         self.manager.increase_processed_receives_statistic(self.stream_id)

--- a/unicorn_binance_websocket_api/manager.py
+++ b/unicorn_binance_websocket_api/manager.py
@@ -4208,6 +4208,11 @@ class BinanceWebSocketApiManager(threading.Thread):
         """
         Add the amount of received bytes per second
 
+        Hot path (once per received message). The per-second dict has a single
+        writer, the stream's own thread, so incrementing an existing key needs
+        no lock. Inserting a new key must hold `stream_list_lock`, because
+        `_frequent_checks()` deep-copies the dict while pruning old entries.
+
         :param stream_id: id of a stream
         :type stream_id: str
         :param size: amount of bytes to add
@@ -4215,84 +4220,43 @@ class BinanceWebSocketApiManager(threading.Thread):
         """
         current_timestamp = int(time.time())
         try:
-            if self.stream_list[stream_id]["transfer_rate_per_second"]["bytes"][
+            self.stream_list[stream_id]["transfer_rate_per_second"]["bytes"][
                 current_timestamp
-            ]:
+            ] += size
+        except KeyError:
+            try:
+                with self.stream_list_lock:
+                    self.stream_list[stream_id]["transfer_rate_per_second"]["bytes"][
+                        current_timestamp
+                    ] = size
+            except KeyError:
                 pass
-        except KeyError:
-            with self.stream_list_lock:
-                logger.debug(
-                    f"BinanceWebSocketApiManager.increase_received_bytes_per_second() - `stream_list_lock` "
-                    f"was entered!"
-                )
-                self.stream_list[stream_id]["transfer_rate_per_second"]["bytes"][
-                    current_timestamp
-                ] = 0
-                logger.debug(
-                    f"BinanceWebSocketApiManager.increase_received_bytes_per_second() - Leaving `stream_list_lock`!"
-                )
-        try:
-            with self.stream_list_lock:
-                logger.debug(
-                    f"BinanceWebSocketApiManager.increase_received_bytes_per_second() - `stream_list_lock` "
-                    f"was entered!"
-                )
-                self.stream_list[stream_id]["transfer_rate_per_second"]["bytes"][
-                    current_timestamp
-                ] += size
-                logger.debug(
-                    f"BinanceWebSocketApiManager.increase_received_bytes_per_second() - Leaving `stream_list_lock`!"
-                )
-        except KeyError:
-            pass
 
     def increase_processed_receives_statistic(self, stream_id):
         """
         Add the number of processed receives
+
+        Hot path (once per received message), same locking rule as
+        `increase_received_bytes_per_second()`: single writer per stream, lock
+        only when a new per-second key is inserted. `total_receives` is shared
+        by all streams and keeps its lock.
 
         :param stream_id: id of a stream
         :type stream_id: str
         """
         current_timestamp = int(time.time())
         try:
-            with self.stream_list_lock:
-                logger.debug(
-                    f"BinanceWebSocketApiManager.increase_processed_receives_statistic() - `stream_list_lock` "
-                    f"was entered!"
-                )
-                self.stream_list[stream_id]["processed_receives_total"] += 1
-                logger.debug(
-                    f"BinanceWebSocketApiManager.increase_processed_receives_statistic() - Leaving "
-                    f"`stream_list_lock`!"
-                )
+            stream = self.stream_list[stream_id]
+            stream["processed_receives_total"] += 1
         except KeyError:
             return False
         try:
-            with self.stream_list_lock:
-                logger.debug(
-                    f"BinanceWebSocketApiManager.increase_processed_receives_statistic() - `stream_list_lock` "
-                    f"was entered!"
-                )
-                self.stream_list[stream_id]["receives_statistic_last_second"][
-                    "entries"
-                ][current_timestamp] += 1
-                logger.debug(
-                    f"BinanceWebSocketApiManager.increase_processed_receives_statistic() - Leaving "
-                    f"`stream_list_lock`!"
-                )
+            stream["receives_statistic_last_second"]["entries"][current_timestamp] += 1
         except KeyError:
             with self.stream_list_lock:
-                logger.debug(
-                    f"BinanceWebSocketApiManager.increase_processed_receives_statistic() - `stream_list_lock` "
-                    f"was entered!"
-                )
-                self.stream_list[stream_id]["receives_statistic_last_second"][
-                    "entries"
-                ][current_timestamp] = 1
-                logger.debug(
-                    f"BinanceWebSocketApiManager.increase_processed_receives_statistic() - Leaving "
-                    f"`stream_list_lock`!"
-                )
+                stream["receives_statistic_last_second"]["entries"][
+                    current_timestamp
+                ] = 1
         with self.total_receives_lock:
             self.total_receives += 1
 
@@ -4376,9 +4340,6 @@ class BinanceWebSocketApiManager(threading.Thread):
         :type stream_id: str
         :return: bool
         """
-        logger.debug(
-            f"BinanceWebSocketApiManager.is_stop_request({stream_id}){self.get_debug_log()}"
-        )
         try:
             if self.stream_list[stream_id]["crash_request"] is True:
                 return True
@@ -4395,9 +4356,6 @@ class BinanceWebSocketApiManager(threading.Thread):
         :type stream_id: str
         :return: bool
         """
-        logger.debug(
-            f"BinanceWebSocketApiManager.is_stop_request({stream_id}){self.get_debug_log()}"
-        )
         try:
             if self.stream_list[stream_id]["stop_request"] is True:
                 return True
@@ -5379,21 +5337,16 @@ class BinanceWebSocketApiManager(threading.Thread):
         """
         Set heartbeat for a specific thread (should only be done by the stream itself)
 
+        Hot path (once per received message). The stream's own thread is the
+        only writer of `last_heartbeat`, so no lock and no per-message debug
+        log here.
+
         :return: None
         """
-        logger.debug("BinanceWebSocketApiManager.set_heartbeat(" + str(stream_id) + ")")
         try:
-            with self.stream_list_lock:
-                logger.debug(
-                    f"BinanceWebSocketApiManager.set_heartbeat() - `stream_list_lock` was entered!"
-                )
-                self.stream_list[stream_id]["last_heartbeat"] = time.time()
-                logger.debug(
-                    f"BinanceWebSocketApiManager.set_heartbeat() - Leaving `stream_list_lock`!"
-                )
+            self.stream_list[stream_id]["last_heartbeat"] = time.time()
         except KeyError:
             pass
-        return None
 
     def set_stop_request(self, stream_id=None):
         """

--- a/unicorn_binance_websocket_api/sockets.py
+++ b/unicorn_binance_websocket_api/sockets.py
@@ -355,10 +355,6 @@ class BinanceWebSocketApiSocket(object):
                                 is not None
                             ):
                                 # if create_stream() got a asyncio consumer task for the asyncio queue -> use it
-                                logger.debug(
-                                    f"BinanceWebSocketApiSocket.start_socket() - Received data set from "
-                                    f"stream_id={self.stream_id} transferred to `asyncio_queue`!"
-                                )
                                 await self.manager.asyncio_queue[self.stream_id].put(
                                     received_stream_data
                                 )
@@ -369,10 +365,6 @@ class BinanceWebSocketApiSocket(object):
                                 is not None
                             ):
                                 # if create_stream() got a callback function -> use it
-                                logger.debug(
-                                    f"BinanceWebSocketApiSocket.start_socket() - Received data set from "
-                                    f"stream_id={self.stream_id} transferred to `process_stream_data`!"
-                                )
                                 self.manager.specific_process_stream_data[
                                     self.stream_id
                                 ](received_stream_data)
@@ -383,49 +375,27 @@ class BinanceWebSocketApiSocket(object):
                                 is not None
                             ):
                                 # if create_stream() got an asynchronous callback function -> use it
-                                logger.debug(
-                                    f"BinanceWebSocketApiSocket.start_socket() - Received data set from "
-                                    f"stream_id={self.stream_id} transferred to "
-                                    f"`process_stream_data_async`!"
-                                )
                                 await self.manager.specific_process_stream_data_async[
                                     self.stream_id
                                 ](received_stream_data)
                             else:
                                 if self.manager.process_asyncio_queue is not None:
                                     # if global asyncio consumer task for the asyncio queue -> use it
-                                    logger.debug(
-                                        f"BinanceWebSocketApiSocket.start_socket() - Received data set from "
-                                        f"stream_id={self.stream_id} transferred to `asyncio_queue`!"
-                                    )
                                     await self.manager.asyncio_queue[
                                         self.stream_id
                                     ].put(received_stream_data)
                                 elif self.manager.process_stream_data is not None:
                                     # if global callback function -> use it
-                                    logger.debug(
-                                        f"BinanceWebSocketApiSocket.start_socket() - Received data set from "
-                                        f"stream_id={self.stream_id} transferred to `process_stream_data`!"
-                                    )
                                     self.manager.process_stream_data(
                                         received_stream_data
                                     )
                                 elif self.manager.process_stream_data_async is not None:
                                     # if global async callback function -> use it
-                                    logger.debug(
-                                        f"BinanceWebSocketApiSocket.start_socket() - Received data set from "
-                                        f"stream_id={self.stream_id} transferred to "
-                                        f"`process_stream_data_async`!"
-                                    )
                                     await self.manager.process_stream_data_async(
                                         received_stream_data
                                     )
                                 else:
                                     # If nothing else is used, write to global stream_buffer
-                                    logger.debug(
-                                        f"BinanceWebSocketApiSocket.start_socket() - Received data set from "
-                                        f"stream_id={self.stream_id} transferred to `stream_buffer`!"
-                                    )
                                     self.manager.add_to_stream_buffer(
                                         received_stream_data
                                     )


### PR DESCRIPTION
## Summary

Profiling pass on the stream loop, follow-up to #475/#476: UBWA added a constant ~5 µs per received message on top of the WebSocket library. Most of it is gone now.

**Where it went** (cProfile of the stream thread, `dev/profile_stream_loop.py`, new):
- 18 `logger.debug(f"...")` calls per message, evaluated with debug logging off (12 of them `lock was entered` / `Leaving lock` pairs)
- 7 lock cycles per message
- `set_heartbeat()` and the stop/crash checks running twice per message (`receive()` and the loop)
- `sys.getsizeof(str(msg))` for the byte statistics

**What changed**
- Debug f-strings in the hot path removed (`set_heartbeat`, `is_stop_request`, `is_crash_request`, `increase_received_bytes_per_second`, `increase_processed_receives_statistic`, `receive`, the dispatch logs in `start_socket`). They carried no information; event/error logs are untouched.
- Per-stream counters take `stream_list_lock` only when a new per-second key is inserted. Rationale: single writer (the stream's own thread); `_frequent_checks()` deep-copies those dicts, so the *insert* must stay locked, the `+=` on an existing key need not.
- `receive()` no longer duplicates `set_heartbeat()` / `raise_exceptions()`; the loop in `start_socket()` does both right before.
- Byte statistics use `len()` of the payload instead of `sys.getsizeof(str())` (~49 bytes per message less, now accurate). Noted under "Changed" in the CHANGELOG.

**Result** (full stack, `raw_data`, median of 3, same machine as the #475 numbers):

| Scenario | websockets before → after | picows before → after |
|---|---|---|
| aggTrade 0.2 KB | 116k → 202k msgs/s | 163k → 403k msgs/s |
| kline 0.3 KB | 113k → 195k | 159k → 371k |
| depth20 1 KB | 97k → 153k | 135k → 260k |
| depth diff 9 KB | 51k → 64k | 52k → 68k |
| multiplex mix | 111k → 180k | 153k → 334k |

picows now sits at ~2.5 µs/msg vs ~2.0 µs for the raw library. Cumulative ablation per stage in `context/stream-loop.md`.

**Docs**: README benchmark section updated and linking the pinned issue #477, CHANGELOG (Added/Changed), llms.txt, AGENTS.md, `context/stream-loop.md` (profile, ablation, lock rule, rejected `if self.debug` guard), `context/websocket-library.md` (before/after tables).

**Tests**: `TestWebSocketLibrary` + restart/resubscribe test locally green; CI runs the rest. Black clean, ktw-lint clean.
