### PR TITLE
test: scenario suite for the websocket_library switch, fix picows InvalidStatus handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,10 @@ python -m unittest unittest_binance_websocket_api.py
 
 Tests in `dev/` are local integration tests that require a live Binance connection — they are **not run in CI**.
 
+`TestWebSocketLibrary` in the unittest file runs its scenarios (reconnect, fragmentation, max_size, ping/pong,
+rejected handshakes, WS API roundtrip, keepalive timeout) against a local stand-in server for both
+`websocket_library` values; no internet needed, picows scenarios skip if picows isn't installed.
+
 **Coverage config:** `.coveragerc` — excludes ~40 platform-specific and hard-to-test lines.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,8 @@ Managed in `requirements.txt`, `setup.py`, and `pyproject.toml` — **all three 
   see [`context/websocket-library.md`](context/websocket-library.md). Benchmark:
   `dev/test_websocket_library_benchmark.py`, profile of the stream thread:
   `dev/profile_stream_loop.py` (per-message cost of the loop itself, see
-  [`context/stream-loop.md`](context/stream-loop.md))
+  [`context/stream-loop.md`](context/stream-loop.md)), 24 h soak against live Binance:
+  `dev/test_soak.py`
 - `requests>=2.31.0` — HTTP
 - `orjson` — fast JSON serialization
 - `unicorn-fy>=0.15.0` — stream data normalization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   0.2 KB messages: `websockets` 116,314 -> 201,912 msgs/s, `picows`
   163,406 -> 403,316 msgs/s, all statistics preserved. Details and
   ablation: [`context/stream-loop.md`](context/stream-loop.md).
+- Received-bytes statistics (`total_received_bytes`,
+  `transfer_rate_per_second`) now count the payload size (`len()` of the
+  received JSON text) instead of `sys.getsizeof(str(...))`, which included
+  the Python object header (~49 bytes per message too many).
 ### Fixed
 - `websocket_library="picows"`: a rejected handshake (HTTP 429/404/...) killed
   the stream thread with `AttributeError: 'WSUpgradeResponse' object has no
@@ -54,11 +58,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   `websockets` shaped one (`status_code`). The manager now reads the code via
   `websocket_library.get_http_status_code()`, which understands both. Found
   by the new scenario tests.
-### Changed
-- Received-bytes statistics (`total_received_bytes`,
-  `transfer_rate_per_second`) now count the payload size (`len()` of the
-  received JSON text) instead of `sys.getsizeof(str(...))`, which included
-  the Python object header (~49 bytes per message too many).
 
 ## 2.15.2
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   [issue #477](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/477).
 - `dev/profile_stream_loop.py`: cProfile of a stream thread against the local
   replay server, to see where UBWA's own per-message time goes.
+- Unit tests for the `websocket_library` switch (`TestWebSocketLibrary`) now
+  run a scenario suite against a local stand-in server for both libraries,
+  no internet needed: reconnect after server close (incl. stream signals),
+  fragmented messages, 450 KB messages, messages above `max_size` (1009 ->
+  reconnect), server ping -> client pong, unicode payloads, received-bytes
+  statistics, rejected handshakes (429 -> stream crashes, 404 -> keeps
+  restarting), a WebSocket API request/response roundtrip and the
+  keepalive ping timeout (server that never pongs -> reconnect).
 ### Changed
 - Stream loop hot path slimmed down (per received message): removed 18
   `logger.debug()` f-string calls that were evaluated with debug logging off,
@@ -38,6 +46,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   0.2 KB messages: `websockets` 116,314 -> 201,912 msgs/s, `picows`
   163,406 -> 403,316 msgs/s, all statistics preserved. Details and
   ablation: [`context/stream-loop.md`](context/stream-loop.md).
+### Fixed
+- `websocket_library="picows"`: a rejected handshake (HTTP 429/404/...) killed
+  the stream thread with `AttributeError: 'WSUpgradeResponse' object has no
+  attribute 'status_code'` instead of crashing/restarting the stream: picows'
+  `InvalidStatus` carries its raw upgrade response (`status`), not the
+  `websockets` shaped one (`status_code`). The manager now reads the code via
+  `websocket_library.get_http_status_code()`, which understands both. Found
+  by the new scenario tests.
+### Changed
 - Received-bytes statistics (`total_received_bytes`,
   `transfer_rate_per_second`) now count the payload size (`len()` of the
   received JSON text) instead of `sys.getsizeof(str(...))`, which included

--- a/README.md
+++ b/README.md
@@ -531,7 +531,9 @@ Selecting `"picows"` without the package installed raises an `ImportError`, an u
 there is no silent fallback. SOCKS5 proxies work with both libraries. The [conda-forge](https://anaconda.org/conda-forge/picows)
 package is `picows`.
 
-Questions, experiences and your own benchmark numbers:
+`picows` support is new and opt-in: `websockets` stays the default until picows has settled (see
+[tarasko/picows#108](https://github.com/tarasko/picows/issues/108)) and enough real-world reports are in. Questions,
+experiences and your own benchmark numbers:
 [issue #477 - WebSocket library: websockets vs. picows](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/477).
 
 #### Is `picows` faster? Measured, not assumed

--- a/context/index.md
+++ b/context/index.md
@@ -72,7 +72,7 @@
 
 ## W
 
-- [websocket-library.md](websocket-library.md) — why `picows` is integrated via its `websockets`-compatible API and the core listener API was measured and not built, separate exception families (incl. the `InvalidStatus.response` shape difference), fail-loud selection, opt-in/non-default status until picows#108 and community feedback, shared SOCKS5 path, and the benchmark numbers behind it
+- [websocket-library.md](websocket-library.md) — why `picows` is integrated via its `websockets`-compatible API and the core listener API was measured and not built, separate exception families (incl. the `InvalidStatus.response` shape difference), fail-loud selection, opt-in/non-default status plus the 24 h soak gate before the release, shared SOCKS5 path, and the benchmark numbers behind it
 
 ## X
 

--- a/context/index.md
+++ b/context/index.md
@@ -72,7 +72,7 @@
 
 ## W
 
-- [websocket-library.md](websocket-library.md) — why `picows` is integrated via its `websockets`-compatible API and the core listener API was measured and not built, separate exception families (incl. the `InvalidStatus.response` shape difference), fail-loud selection, shared SOCKS5 path, and the benchmark numbers behind it
+- [websocket-library.md](websocket-library.md) — why `picows` is integrated via its `websockets`-compatible API and the core listener API was measured and not built, separate exception families (incl. the `InvalidStatus.response` shape difference), fail-loud selection, opt-in/non-default status until picows#108 and community feedback, shared SOCKS5 path, and the benchmark numbers behind it
 
 ## X
 

--- a/context/index.md
+++ b/context/index.md
@@ -72,7 +72,7 @@
 
 ## W
 
-- [websocket-library.md](websocket-library.md) — why `picows` is integrated via its `websockets`-compatible API and the core listener API was measured and not built, separate exception families, fail-loud selection, shared SOCKS5 path, and the benchmark numbers behind it
+- [websocket-library.md](websocket-library.md) — why `picows` is integrated via its `websockets`-compatible API and the core listener API was measured and not built, separate exception families (incl. the `InvalidStatus.response` shape difference), fail-loud selection, shared SOCKS5 path, and the benchmark numbers behind it
 
 ## X
 

--- a/context/websocket-library.md
+++ b/context/websocket-library.md
@@ -97,7 +97,7 @@ userData, memory and reconnect counters per hour, then the same with
 has fixed #108, so the soak measures the final compat layer rather than
 the workaround.
 
-
+## Why the picows exception classes are caught separately
 
 **Type:** constraint
 **Status:** active

--- a/context/websocket-library.md
+++ b/context/websocket-library.md
@@ -88,7 +88,7 @@ picows classes are appended only when the package is importable.
 **Status:** active
 **Evidence:** confirmed
 **Source:** picows 2.1.3 `picows/websockets/asyncio/client.py` (`raise InvalidStatus(exc.response)` with the raw `WSUpgradeResponse`); found by `TestWebSocketLibrary.test_handshake_429_crashes_stream`
-**Revisit when:** picows wraps the response in its compat `Response` (which has `status_code`) - then the helper can go back to reading `status_code` only
+**Revisit when:** [tarasko/picows#108](https://github.com/tarasko/picows/issues/108) is fixed and released (picows wraps the response in its compat `Response`, which has `status_code`) - then the helper can go back to reading `status_code` only
 
 The manager decides on a rejected handshake by HTTP status (429 -> crash the
 stream, anything else -> restart). `websockets` puts a `Response` with

--- a/context/websocket-library.md
+++ b/context/websocket-library.md
@@ -69,33 +69,36 @@ side benefits are reachable inside the existing pull loop.
 (`"websockets"`, `"picows"`). The performance lever, if wanted, is UBWA's own
 per-message work - see `stream-loop.md`.
 
-## picows stays opt-in and non-default until it has proven itself
+## picows stays opt-in and non-default; 24 h soak before the release
 
 **Type:** decision
 **Status:** active
 **Evidence:** confirmed
-**Source:** maintainer decision 2026-09-10 after the scenario suite (PR #479) and the upstream report [tarasko/picows#108](https://github.com/tarasko/picows/issues/108)
-**Revisit when:** picows has fixed and released #108 and user reports in [issue #477](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/477) have been collected - then decide about a soak test and about promoting picows beyond opt-in
+**Source:** maintainer decisions 2026-09-10 (opt-in after the scenario suite of PR #479 and the upstream report [tarasko/picows#108](https://github.com/tarasko/picows/issues/108); soak requested the same day, release only after it)
+**Revisit when:** the soak result is in (see below) and picows has fixed and released #108 - then decide about promoting picows beyond opt-in
 
 picows support ships as an optional extra (`pip install
 unicorn-binance-websocket-api[picows]`), selected explicitly per manager,
-`websockets` remains the default. This is deliberately left as is for now:
-the integration is covered by the local scenario suite and a short live
-run, but not by a long soak (hours against real Binance maintenance
-windows and the 24 h connection limit), not with userData streams or the
-WS API against real credentials, and only on Linux.
+`websockets` remains the default. The local scenario suite and short live
+runs cover the integration; what they do not cover is time: hours against
+real Binance maintenance windows and the 24 h connection limit, memory over
+time. That gap is closed by a 24 h soak (`dev/test_soak.py`: `!ticker@arr`
++ `!miniTicker@arr`, five channels on the top 50 USDT markets, `depth@100ms`
+on 20 of them, both libraries in parallel on the same host, metrics once a
+minute) before the release that ships picows support.
 
 **Reason:** the remaining risk sits with users who opt in knowingly, the
-default path is untouched, and picows' compat layer itself is still
-moving (#108). Letting real usage surface the next issues costs less than
-a synthetic soak now; the community feedback channel is #477.
+default path is untouched, and picows' compat layer itself is still moving
+(#108). Real usage is expected to surface the next issues; the community
+channel is [issue #477](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/477). The
+soak is the minimum evidence for "runs for a day" before telling anyone to
+opt in.
 
-**Rejected alternative:** a 24 h soak on the development VM before calling
-it production-ready (picows, `!ticker@arr` plus ~50 symbols, testnet
-userData, memory and reconnect counters per hour, then the same with
-`websockets` as reference). Not rejected on merit - deferred until picows
-has fixed #108, so the soak measures the final compat layer rather than
-the workaround.
+**Not covered by the soak:** userData streams and the WebSocket API against
+real credentials (no testnet key on the soak host), macOS/Windows.
+
+**Soak result:** pending (started 2026-09-10 16:19 CEST, results under the
+soak output directory, to be summarized here).
 
 ## Why the picows exception classes are caught separately
 

--- a/context/websocket-library.md
+++ b/context/websocket-library.md
@@ -82,7 +82,30 @@ restart logic therefore catches tuples
 (`CONNECTION_CLOSED_EXCEPTIONS`, ...) built in `websocket_library.py`; the
 picows classes are appended only when the package is importable.
 
-## Fail loud on `picows` without the package
+## `InvalidStatus.response` differs between the families
+
+**Type:** workaround
+**Status:** active
+**Evidence:** confirmed
+**Source:** picows 2.1.3 `picows/websockets/asyncio/client.py` (`raise InvalidStatus(exc.response)` with the raw `WSUpgradeResponse`); found by `TestWebSocketLibrary.test_handshake_429_crashes_stream`
+**Revisit when:** picows wraps the response in its compat `Response` (which has `status_code`) - then the helper can go back to reading `status_code` only
+
+The manager decides on a rejected handshake by HTTP status (429 -> crash the
+stream, anything else -> restart). `websockets` puts a `Response` with
+`status_code` on `InvalidStatus`; `picows.websockets` puts picows' raw
+`WSUpgradeResponse` there, which only has `status` (an `HTTPStatus`).
+Reading `.status_code` therefore raised `AttributeError` inside the
+`except` clause and the stream thread died silently, no status update, no
+restart - the exact failure mode the fail-loud rule exists to prevent.
+`websocket_library.get_http_status_code()` reads either attribute; the
+manager uses it instead of touching the response directly.
+
+**Rejected alternative:** catching the picows exception separately and
+mapping it before the shared handler. More code for the same outcome, and
+the next attribute difference would need the same treatment again; one
+accessor that knows both shapes is the smaller surface.
+
+
 
 **Type:** decision
 **Status:** active

--- a/context/websocket-library.md
+++ b/context/websocket-library.md
@@ -105,7 +105,7 @@ mapping it before the shared handler. More code for the same outcome, and
 the next attribute difference would need the same treatment again; one
 accessor that knows both shapes is the smaller surface.
 
-
+## Fail loud on `picows` without the package
 
 **Type:** decision
 **Status:** active

--- a/context/websocket-library.md
+++ b/context/websocket-library.md
@@ -69,7 +69,35 @@ side benefits are reachable inside the existing pull loop.
 (`"websockets"`, `"picows"`). The performance lever, if wanted, is UBWA's own
 per-message work - see `stream-loop.md`.
 
-## Why the picows exception classes are caught separately
+## picows stays opt-in and non-default until it has proven itself
+
+**Type:** decision
+**Status:** active
+**Evidence:** confirmed
+**Source:** maintainer decision 2026-09-10 after the scenario suite (PR #479) and the upstream report [tarasko/picows#108](https://github.com/tarasko/picows/issues/108)
+**Revisit when:** picows has fixed and released #108 and user reports in [issue #477](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/477) have been collected - then decide about a soak test and about promoting picows beyond opt-in
+
+picows support ships as an optional extra (`pip install
+unicorn-binance-websocket-api[picows]`), selected explicitly per manager,
+`websockets` remains the default. This is deliberately left as is for now:
+the integration is covered by the local scenario suite and a short live
+run, but not by a long soak (hours against real Binance maintenance
+windows and the 24 h connection limit), not with userData streams or the
+WS API against real credentials, and only on Linux.
+
+**Reason:** the remaining risk sits with users who opt in knowingly, the
+default path is untouched, and picows' compat layer itself is still
+moving (#108). Letting real usage surface the next issues costs less than
+a synthetic soak now; the community feedback channel is #477.
+
+**Rejected alternative:** a 24 h soak on the development VM before calling
+it production-ready (picows, `!ticker@arr` plus ~50 symbols, testnet
+userData, memory and reconnect counters per hour, then the same with
+`websockets` as reference). Not rejected on merit - deferred until picows
+has fixed #108, so the soak measures the final compat layer rather than
+the workaround.
+
+
 
 **Type:** constraint
 **Status:** active

--- a/dev/test_soak.py
+++ b/dev/test_soak.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# File: dev/test_soak.py
+#
+# Part of ‘UNICORN Binance WebSocket API’
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-websocket-api
+# PyPI: https://pypi.org/project/unicorn-binance-websocket-api
+#
+# Author: Oliver Zehentleitner
+#
+# Copyright (c) 2019-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish, dis-
+# tribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the fol-
+# lowing conditions:
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABIL-
+# ITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+# SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""
+Soak test: run a heavy live multiplex against Binance for hours with one
+`websocket_library` and record health metrics once a minute.
+
+Not part of CI. Streams (all on `--exchange`, default binance.com):
+
+- `!ticker@arr` + `!miniTicker@arr`
+- aggTrade / trade / depth20@100ms / kline_1m / bookTicker for the top
+  `--symbols` USDT markets by 24h quote volume (fetched via REST at start)
+- `depth@100ms` (diff depth) for the top 20 of those
+- optional, when `BINANCE_TESTNET_API_KEY` / `BINANCE_TESTNET_API_SECRET`
+  are set: a second manager on binance.com-testnet with a `!userData` stream
+  and a WebSocket API stream that calls `get_server_time()` once a minute
+  (return_response=True) - exercises the userData + WS API paths live.
+
+Every minute one CSV row per run (messages, bytes, rate, reconnects, stream
+statuses, seconds since last data per stream, RSS, CPU %, threads, error
+count, WS API ok/failed), plus a signals log with every stream signal.
+
+Usage:
+    python3 dev/test_soak.py --library picows --hours 24 --out ./soak/picows
+    python3 dev/test_soak.py --library websockets --hours 24 --out ./soak/websockets
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from unicorn_binance_websocket_api.manager import (  # noqa: E402
+    BinanceWebSocketApiManager,
+)
+import argparse  # noqa: E402
+import csv  # noqa: E402
+import logging  # noqa: E402
+import platform  # noqa: E402
+import psutil  # noqa: E402
+import requests  # noqa: E402
+import signal  # noqa: E402
+import threading  # noqa: E402
+import time  # noqa: E402
+
+
+def top_usdt_symbols(count, exclude_stable=("USDCUSDT", "FDUSDUSDT", "TUSDUSDT")):
+    tickers = requests.get(
+        "https://api.binance.com/api/v3/ticker/24hr", timeout=20
+    ).json()
+    usdt = [
+        t
+        for t in tickers
+        if t["symbol"].endswith("USDT") and t["symbol"] not in exclude_stable
+    ]
+    usdt.sort(key=lambda t: float(t["quoteVolume"]), reverse=True)
+    return [t["symbol"].lower() for t in usdt[:count]]
+
+
+class Soak:
+    def __init__(self, args):
+        self.args = args
+        self.lock = threading.Lock()
+        self.messages = 0
+        self.bytes = 0
+        self.last_data = {}  # stream_id -> time.time() of the last message
+        self.signals = []
+        self.api_ok = 0
+        self.api_failed = 0
+        self.stop = threading.Event()
+        os.makedirs(args.out, exist_ok=True)
+        self.signals_file = open(os.path.join(args.out, "signals.log"), "a")
+        self.csv_path = os.path.join(args.out, "metrics.csv")
+        self.process = psutil.Process()
+        self.process.cpu_percent(interval=None)
+
+    # --- callbacks (hot path: keep them cheap) ---------------------------------
+    def on_data(self, data):
+        # raw_data output -> `data` is the JSON string; UBWA prepends nothing
+        with self.lock:
+            self.messages += 1
+            self.bytes += len(data)
+
+    def on_signal(
+        self, signal_type=None, stream_id=None, data_record=None, error_msg=None
+    ):
+        line = f"{time.strftime('%Y-%m-%d %H:%M:%S')} {signal_type} stream_id={stream_id} error_msg={error_msg}\n"
+        try:
+            self.signals_file.write(line)
+            self.signals_file.flush()
+        except ValueError:
+            pass  # file already closed during shutdown
+
+    # --- setup -----------------------------------------------------------------
+    def start(self):
+        args = self.args
+        self.ubwa = BinanceWebSocketApiManager(
+            exchange=args.exchange,
+            websocket_library=args.library,
+            output_default="raw_data",
+            process_stream_data=self.on_data,
+            process_stream_signals=self.on_signal,
+            warn_on_update=False,
+            disable_colorama=True,
+        )
+        symbols = top_usdt_symbols(args.symbols)
+        self.streams = {
+            "arr": self.ubwa.create_stream(
+                ["arr"], ["!ticker", "!miniTicker"], stream_label="arr"
+            ),
+            "markets": self.ubwa.create_stream(
+                ["aggTrade", "trade", "depth20@100ms", "kline_1m", "bookTicker"],
+                symbols,
+                stream_label="markets",
+            ),
+            "depth": self.ubwa.create_stream(
+                ["depth@100ms"], symbols[:20], stream_label="depth"
+            ),
+        }
+        self.testnet = None
+        key, secret = os.getenv("BINANCE_TESTNET_API_KEY"), os.getenv(
+            "BINANCE_TESTNET_API_SECRET"
+        )
+        if key and secret:
+            self.testnet = BinanceWebSocketApiManager(
+                exchange="binance.com-testnet",
+                websocket_library=args.library,
+                output_default="dict",
+                process_stream_data=self.on_data_testnet,
+                process_stream_signals=self.on_signal,
+                warn_on_update=False,
+                disable_colorama=True,
+            )
+            self.streams["userdata"] = self.testnet.create_stream(
+                ["arr"],
+                ["!userData"],
+                api_key=key,
+                api_secret=secret,
+                stream_label="userData",
+            )
+            self.streams["api"] = self.testnet.create_stream(
+                api=True, api_key=key, api_secret=secret, stream_label="api"
+            )
+        print(
+            f"soak {args.library} on {args.exchange}: {len(symbols)} symbols, streams={list(self.streams)}, "
+            f"testnet={'yes' if self.testnet else 'no (BINANCE_TESTNET_API_KEY not set)'}",
+            flush=True,
+        )
+
+    def on_data_testnet(self, data):
+        with self.lock:
+            self.messages += 1
+
+    def manager_of(self, name):
+        return self.testnet if name in ("userdata", "api") else self.ubwa
+
+    # --- metrics ---------------------------------------------------------------
+    def api_probe(self):
+        if self.testnet is None:
+            return
+        try:
+            response = self.testnet.api.spot.get_server_time(
+                stream_id=self.streams["api"], return_response=True
+            )
+            if response and response.get("status") == 200:
+                self.api_ok += 1
+            else:
+                self.api_failed += 1
+        except Exception:
+            self.api_failed += 1
+
+    def row(self, previous):
+        now = time.time()
+        with self.lock:
+            messages, received_bytes = self.messages, self.bytes
+        row = {
+            "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "uptime_s": int(now - self.started),
+            "messages_total": messages,
+            "messages_per_s": round(
+                (messages - previous["messages"]) / max(now - previous["time"], 1), 1
+            ),
+            "mb_total": round(received_bytes / 1e6, 1),
+            "rss_mb": round(self.process.memory_info().rss / 1e6, 1),
+            "cpu_pct": round(self.process.cpu_percent(interval=None), 1),
+            "threads": self.process.num_threads(),
+            "errors": len(self.ubwa.ringbuffer_error),
+            "api_ok": self.api_ok,
+            "api_failed": self.api_failed,
+        }
+        for name, stream_id in self.streams.items():
+            manager = self.manager_of(name)
+            info = manager.get_stream_info(stream_id) or {}
+            row[f"{name}_status"] = str(info.get("status", "?"))[:12]
+            row[f"{name}_reconnects"] = info.get("reconnects", "?")
+            last = info.get("last_heartbeat") or 0
+            row[f"{name}_last_data_s"] = int(now - last) if last else -1
+            row[f"{name}_receives"] = info.get("processed_receives_total", "?")
+        return row, {"messages": messages, "time": now}
+
+    def run(self):
+        self.started = time.time()
+        end = self.started + self.args.hours * 3600
+        previous = {"messages": 0, "time": self.started}
+        write_header = not os.path.exists(self.csv_path)
+        with open(self.csv_path, "a", newline="") as f:
+            writer = None
+            while not self.stop.is_set() and time.time() < end:
+                self.stop.wait(self.args.interval)
+                self.api_probe()
+                row, previous = self.row(previous)
+                if writer is None:
+                    writer = csv.DictWriter(f, fieldnames=list(row))
+                    if write_header:
+                        writer.writeheader()
+                writer.writerow(row)
+                f.flush()
+                print(
+                    f"{row['timestamp']} msgs={row['messages_total']:,} ({row['messages_per_s']}/s) "
+                    f"rss={row['rss_mb']}MB cpu={row['cpu_pct']}% "
+                    + " ".join(
+                        f"{n}={row[f'{n}_status']}/{row[f'{n}_reconnects']}"
+                        for n in self.streams
+                    ),
+                    flush=True,
+                )
+        self.shutdown()
+
+    def shutdown(self):
+        print("stopping ...", flush=True)
+        self.ubwa.stop_manager()
+        if self.testnet is not None:
+            self.testnet.stop_manager()
+        time.sleep(3)  # let the DISCONNECT signals of the stopping streams land
+        self.signals_file.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--library", default="picows", choices=["websockets", "picows"])
+    parser.add_argument("--exchange", default="binance.com")
+    parser.add_argument("--hours", type=float, default=24)
+    parser.add_argument("--symbols", type=int, default=50)
+    parser.add_argument(
+        "--interval", type=int, default=60, help="seconds between metric rows"
+    )
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        filename=os.path.join(args.out, "ubwa.log"),
+        format="{asctime} [{levelname:8}] {module}: {message}",
+        style="{",
+    )
+    print(
+        f"Python {platform.python_version()} {platform.system()} {platform.machine()}",
+        flush=True,
+    )
+    soak = Soak(args)
+    signal.signal(signal.SIGTERM, lambda *_: soak.stop.set())
+    signal.signal(signal.SIGINT, lambda *_: soak.stop.set())
+    soak.start()
+    soak.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/unicorn_binance_websocket_api/manager.py
+++ b/unicorn_binance_websocket_api/manager.py
@@ -54,6 +54,7 @@ from .websocket_library import (
     INVALID_MESSAGE_EXCEPTIONS,
     INVALID_STATUS_EXCEPTIONS,
     NEGOTIATION_ERROR_EXCEPTIONS,
+    get_http_status_code,
     get_websocket_library_version,
     validate_websocket_library,
 )
@@ -584,7 +585,7 @@ class BinanceWebSocketApiManager(threading.Thread):
                 )
                 self._stream_is_restarting(stream_id=stream_id, error_msg=error_msg)
             except INVALID_STATUS_EXCEPTIONS as error_msg:
-                status_code = error_msg.response.status_code
+                status_code = get_http_status_code(error_msg)
                 logger.error(
                     f"BinanceWebSocketApiManager._run_socket(stream_id={stream_id}), channels="
                     f"{channels}), markets={markets}) - websockets.exceptions.InvalidStatus: {error_msg}"

--- a/unicorn_binance_websocket_api/websocket_library.py
+++ b/unicorn_binance_websocket_api/websocket_library.py
@@ -94,6 +94,28 @@ INVALID_MESSAGE_EXCEPTIONS = _exception_tuple("InvalidMessage")
 NEGOTIATION_ERROR_EXCEPTIONS = _exception_tuple("NegotiationError")
 
 
+def get_http_status_code(error: BaseException) -> Optional[int]:
+    """
+    HTTP status of a rejected handshake (`InvalidStatus` of either family).
+
+    `websockets` attaches a `Response` with `status_code`; `picows.websockets`
+    (2.1.x) attaches picows' raw `WSUpgradeResponse`, which only has
+    `status` (an `HTTPStatus`). Reading `.status_code` blindly killed the
+    stream thread with an `AttributeError` on picows - a silent death instead
+    of the crash/restart decision the manager makes from the code.
+    """
+    response = getattr(error, "response", None)
+    code = getattr(response, "status_code", None)
+    if code is None:
+        code = getattr(response, "status", None)
+    if code is None:
+        return None
+    try:
+        return int(code)
+    except (TypeError, ValueError):
+        return None
+
+
 def is_picows_available() -> bool:
     return picows_websockets is not None
 

--- a/unittest_binance_websocket_api.py
+++ b/unittest_binance_websocket_api.py
@@ -1693,97 +1693,210 @@ class TestRestclientUnknownExchangeIsHandled(unittest.TestCase):
         self.assertEqual(rc.delete_listen_key(stream_id="id1"), (None, None))
 
 
+class _LocalWebSocketServer:
+    """
+    Deterministic local stand-in for Binance, used by `TestWebSocketLibrary`.
+
+    One `websockets` server; the scenario is selected by the market name in
+    UBWA's stream URI (`/stream?streams=<market>@<channel>`), the WebSocket API
+    base URI maps to the `api` scenario. Every connection answers client
+    requests like Binance does (`{"result": null, "id": ...}`, WS API requests
+    with a `status`/`result` envelope) and sends a heartbeat message every
+    0.5 s so that UBWA's untimed `recv()` (see context/stream-loop.md) can be
+    stopped.
+    """
+
+    def __init__(self):
+        self.port = None
+        self.ready = threading.Event()
+        self.connections = {}
+        self.pongs = {}
+        self.thread = None
+
+    def start(self):
+        self.thread = threading.Thread(
+            target=lambda: asyncio.run(self._serve()), daemon=True
+        )
+        self.thread.start()
+        self.ready.wait(10)
+
+    async def _serve(self):
+        import websockets
+
+        async with websockets.serve(
+            self._handler,
+            "127.0.0.1",
+            0,
+            process_request=self._process_request,
+            max_size=None,
+        ) as server:
+            self.port = server.sockets[0].getsockname()[1]
+            self.ready.set()
+            await asyncio.Future()
+
+    @staticmethod
+    def _scenario_of(path):
+        if path.startswith("/ws-api"):
+            return "api"
+        streams = (
+            path.split("streams=")[-1]
+            if "streams=" in path
+            else path.rsplit("/", 1)[-1]
+        )
+        return streams.split("@")[0].split("/")[0]
+
+    def _process_request(self, connection, request):
+        scenario = self._scenario_of(request.path)
+        self.connections[scenario] = self.connections.get(scenario, 0) + 1
+        if scenario == "http429":
+            return connection.respond(429, "Too Many Requests\n")
+        if scenario == "http404":
+            return connection.respond(404, "Not Found\n")
+        return None
+
+    async def _handler(self, ws):
+        scenario = self._scenario_of(ws.request.path)
+        connection_number = self.connections.get(scenario, 1)
+
+        async def heartbeat():
+            while True:
+                await asyncio.sleep(0.5)
+                await ws.send('{"heartbeat":true}')
+
+        heartbeat_task = asyncio.create_task(heartbeat())
+        try:
+            scenario_coroutine = getattr(self, f"_scenario_{scenario}", None)
+            if scenario_coroutine is not None:
+                await scenario_coroutine(ws, connection_number)
+            async for msg in ws:
+                request = orjson.loads(msg)
+                if request.get("method") == "time":
+                    await ws.send(
+                        f'{{"id":"{request["id"]}","status":200,'
+                        f'"result":{{"serverTime":1234567890123}}}}'
+                    )
+                else:
+                    await ws.send(f'{{"result":null,"id":{request["id"]}}}')
+        except Exception:
+            pass
+        finally:
+            heartbeat_task.cancel()
+
+    @staticmethod
+    def _trade(scenario, number):
+        return f'{{"stream":"{scenario}@trade","data":{{"e":"trade","s":"TEST","t":{number}}}}}'
+
+    async def _scenario_btcusdt(self, ws, connection_number):
+        # Stay idle first: exercises UBWA's `asyncio.wait_for(recv(), 1)`
+        # timeout/cancel path before the first message arrives.
+        await asyncio.sleep(2)
+        for i in range(25):
+            await ws.send(self._trade("btcusdt", i))
+
+    async def _scenario_reconnect(self, ws, connection_number):
+        for i in range(5):
+            await ws.send(
+                self._trade("reconnect", i + (5 if connection_number > 1 else 0))
+            )
+        if connection_number == 1:
+            # Let the client's subscribe request through first, otherwise its
+            # `send()` hits the closed connection before `recv()` ever read
+            # the five trades above.
+            request = orjson.loads(await ws.recv())
+            await ws.send(f'{{"result":null,"id":{request["id"]}}}')
+            await ws.close(1001, "going away")
+
+    async def _scenario_fragment(self, ws, connection_number):
+        # An iterable makes `websockets` send one message as several frames
+        # (FIN only on the last one) - the client has to reassemble it.
+        message = self._trade("fragment", 0)
+        third = len(message) // 3
+        await ws.send(
+            [message[:third], message[third : 2 * third], message[2 * third :]]
+        )
+
+    async def _scenario_large(self, ws, connection_number):
+        # ~450 KB, the size of a real `!ticker@arr` message, below the 1 MiB
+        # default `max_size` of both libraries.
+        items = ",".join(f'{{"s":"SYM{i:04d}","c":"{i}.0"}}' for i in range(20000))
+        await ws.send(f'{{"stream":"large@trade","data":[{items}]}}')
+
+    async def _scenario_toolarge(self, ws, connection_number):
+        # 1.5 MiB on the first connection only: above `max_size`, the client
+        # must close with 1009 and UBWA must reconnect - not hang.
+        if connection_number == 1:
+            await ws.send(
+                '{"stream":"toolarge@trade","data":"' + "x" * (1536 * 1024) + '"}'
+            )
+        else:
+            await ws.send(self._trade("toolarge", 0))
+
+    async def _scenario_ping(self, ws, connection_number):
+        # Binance pings its clients and drops them without a pong; both
+        # libraries have to answer server pings automatically.
+        pong_waiter = await ws.ping()
+        await asyncio.wait_for(pong_waiter, 5)
+        self.pongs["ping"] = True
+        await ws.send(self._trade("ping", 0))
+
+    async def _scenario_unicode(self, ws, connection_number):
+        await ws.send('{"stream":"unicode@trade","data":{"e":"trade","s":"€ÜŸ–日本"}}')
+
+    async def _scenario_bytes(self, ws, connection_number):
+        for i in range(3):
+            await ws.send(self._trade("bytes", i) + " " * (100 * i))
+
+
 class TestWebSocketLibrary(unittest.TestCase):
     """
     `websocket_library` switch: `websockets` (default) vs. the optional `picows`
-    (`picows.websockets` compatibility API). The roundtrip test runs against a
-    local server so it is deterministic and works without internet access.
+    (`picows.websockets` compatibility API). Scenario tests run against the
+    local server above for both libraries, so they are deterministic and work
+    without internet access. picows scenarios are skipped if it isn't installed.
     """
-
-    LOCAL_PORT = 18765
-    LOCAL_MESSAGES = 25
 
     @classmethod
     def setUpClass(cls):
         print(f"\r\nTestWebSocketLibrary:")
-        import websockets
+        cls.server = _LocalWebSocketServer()
+        cls.server.start()
+        from unicorn_binance_websocket_api import websocket_library
 
-        cls.server_ready = threading.Event()
+        cls.libraries = ["websockets"]
+        if websocket_library.is_picows_available():
+            cls.libraries.append("picows")
 
-        async def handler(ws):
-            # Stay idle first: exercises UBWA's `asyncio.wait_for(recv(), 1)`
-            # timeout/cancel path before the first message arrives.
-            await asyncio.sleep(2)
-            for i in range(cls.LOCAL_MESSAGES):
-                await ws.send(
-                    f'{{"stream":"btcusdt@trade","data":{{"e":"trade","s":"BTCUSDT","t":{i}}}}}'
-                )
-
-            # Answer every client request (UBWA may queue a subscribe payload
-            # on `create_stream()`, the test adds one more explicitly). A
-            # heartbeat keeps data flowing: once a stream has subscriptions and
-            # more than 10 receives, UBWA awaits `recv()` without timeout, so
-            # `stop_stream()` only takes effect when the next message arrives.
-            async def heartbeat():
-                while True:
-                    await asyncio.sleep(0.5)
-                    await ws.send('{"heartbeat":true}')
-
-            heartbeat_task = asyncio.create_task(heartbeat())
-            try:
-                async for msg in ws:
-                    request_id = orjson.loads(msg)["id"]
-                    await ws.send(f'{{"result":null,"id":{request_id}}}')
-            except Exception:
-                pass
-            finally:
-                heartbeat_task.cancel()
-
-        async def serve():
-            async with websockets.serve(handler, "127.0.0.1", cls.LOCAL_PORT):
-                cls.server_ready.set()
-                await asyncio.Future()
-
-        cls.server_thread = threading.Thread(
-            target=lambda: asyncio.run(serve()), daemon=True
-        )
-        cls.server_thread.start()
-        cls.server_ready.wait(10)
-
-    def _roundtrip(self, websocket_library):
-        received = []
-        ubwa = BinanceWebSocketApiManager(
+    def _manager(self, websocket_library, scenario=None, **kwargs):
+        # Scenarios that behave differently per connection count from zero
+        # for every (library, scenario) sub-test.
+        if scenario is not None:
+            self.server.connections.pop(scenario, None)
+        options = dict(
             exchange="binance.com",
             websocket_library=websocket_library,
-            websocket_base_uri=f"ws://127.0.0.1:{self.LOCAL_PORT}/",
+            websocket_base_uri=f"ws://127.0.0.1:{self.server.port}/",
+            websocket_api_base_uri=f"ws://127.0.0.1:{self.server.port}/ws-api/v3",
             output_default="dict",
-            process_stream_data=lambda data: received.append(data),
             warn_on_update=False,
             disable_colorama=True,
         )
-        try:
-            self.assertEqual(ubwa.websocket_library, websocket_library)
-            stream_id = ubwa.create_stream(["trade"], ["btcusdt"])
+        options.update(kwargs)
+        return BinanceWebSocketApiManager(**options)
 
-            def trades():
-                return [item for item in received if "data" in item]
+    @staticmethod
+    def _wait_for(condition, timeout=20):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if condition():
+                return True
+            time.sleep(0.05)
+        return condition()
 
-            deadline = time.time() + 20
-            while len(trades()) < self.LOCAL_MESSAGES and time.time() < deadline:
-                time.sleep(0.1)
-            self.assertEqual(len(trades()), self.LOCAL_MESSAGES)
-            self.assertEqual(trades()[0]["data"]["t"], 0)
-            results_before = len(ubwa.get_results_from_endpoints())
-            ubwa.subscribe_to_stream(stream_id, channels=["kline_1m"])
-            deadline = time.time() + 10
-            while (
-                len(ubwa.get_results_from_endpoints()) <= results_before
-                and time.time() < deadline
-            ):
-                time.sleep(0.1)
-            self.assertEqual(len(ubwa.get_results_from_endpoints()), results_before + 1)
-        finally:
-            ubwa.stop_manager()
+    @staticmethod
+    def _trades(received):
+        return [item for item in received if isinstance(item, dict) and "data" in item]
+
+    # --- switch -------------------------------------------------------------
 
     def test_default_is_websockets(self):
         print(f"test_default_is_websockets():")
@@ -1815,17 +1928,312 @@ class TestWebSocketLibrary(unittest.TestCase):
                     disable_colorama=True,
                 )
 
-    def test_roundtrip_websockets(self):
-        print(f"test_roundtrip_websockets():")
-        self._roundtrip("websockets")
+    # --- scenarios, both libraries -------------------------------------------
 
-    def test_roundtrip_picows(self):
-        print(f"test_roundtrip_picows():")
-        from unicorn_binance_websocket_api import websocket_library
+    def test_roundtrip(self):
+        print(f"test_roundtrip():")
+        for library in self.libraries:
+            with self.subTest(library=library):
+                received = []
+                ubwa = self._manager(library, process_stream_data=received.append)
+                try:
+                    self.assertEqual(ubwa.websocket_library, library)
+                    stream_id = ubwa.create_stream(["trade"], ["btcusdt"])
+                    self.assertTrue(
+                        self._wait_for(lambda: len(self._trades(received)) >= 25)
+                    )
+                    self.assertEqual(len(self._trades(received)), 25)
+                    self.assertEqual(self._trades(received)[0]["data"]["t"], 0)
+                    results_before = len(ubwa.get_results_from_endpoints())
+                    ubwa.subscribe_to_stream(stream_id, channels=["kline_1m"])
+                    self.assertTrue(
+                        self._wait_for(
+                            lambda: len(ubwa.get_results_from_endpoints())
+                            > results_before,
+                            10,
+                        )
+                    )
+                    self.assertEqual(ubwa.get_stream_info(stream_id)["reconnects"], 0)
+                finally:
+                    ubwa.stop_manager()
 
-        if not websocket_library.is_picows_available():
+    def test_reconnect_after_server_close(self):
+        print(f"test_reconnect_after_server_close():")
+        for library in self.libraries:
+            with self.subTest(library=library):
+                received, signals = [], []
+                ubwa = self._manager(
+                    library,
+                    scenario="reconnect",
+                    process_stream_data=received.append,
+                    process_stream_signals=lambda signal_type=None, stream_id=None, data_record=None, error_msg=None: signals.append(
+                        signal_type
+                    ),
+                )
+                try:
+                    stream_id = ubwa.create_stream(["trade"], ["reconnect"])
+                    self.assertTrue(
+                        self._wait_for(lambda: len(self._trades(received)) >= 10)
+                    )
+                    self.assertEqual(
+                        [t["data"]["t"] for t in self._trades(received)],
+                        list(range(10)),
+                    )
+                    self.assertTrue(
+                        self._wait_for(
+                            lambda: ubwa.get_stream_info(stream_id)["reconnects"] == 1,
+                            5,
+                        )
+                    )
+                    self.assertIn("DISCONNECT", signals)
+                    self.assertEqual(signals.count("CONNECT"), 2)
+                finally:
+                    ubwa.stop_manager()
+
+    def test_fragmented_message(self):
+        print(f"test_fragmented_message():")
+        for library in self.libraries:
+            with self.subTest(library=library):
+                received = []
+                ubwa = self._manager(library, process_stream_data=received.append)
+                try:
+                    ubwa.create_stream(["trade"], ["fragment"])
+                    self.assertTrue(
+                        self._wait_for(lambda: len(self._trades(received)) >= 1)
+                    )
+                    self.assertEqual(
+                        self._trades(received)[0]["data"],
+                        {"e": "trade", "s": "TEST", "t": 0},
+                    )
+                finally:
+                    ubwa.stop_manager()
+
+    def test_large_message(self):
+        print(f"test_large_message():")
+        for library in self.libraries:
+            with self.subTest(library=library):
+                received = []
+                ubwa = self._manager(library, process_stream_data=received.append)
+                try:
+                    stream_id = ubwa.create_stream(["trade"], ["large"])
+                    self.assertTrue(
+                        self._wait_for(lambda: len(self._trades(received)) >= 1)
+                    )
+                    self.assertEqual(len(self._trades(received)[0]["data"]), 20000)
+                    self.assertEqual(ubwa.get_stream_info(stream_id)["reconnects"], 0)
+                finally:
+                    ubwa.stop_manager()
+
+    def test_message_above_max_size_reconnects(self):
+        print(f"test_message_above_max_size_reconnects():")
+        for library in self.libraries:
+            with self.subTest(library=library):
+                received = []
+                ubwa = self._manager(
+                    library, scenario="toolarge", process_stream_data=received.append
+                )
+                try:
+                    stream_id = ubwa.create_stream(["trade"], ["toolarge"])
+                    self.assertTrue(
+                        self._wait_for(lambda: len(self._trades(received)) >= 1)
+                    )
+                    self.assertEqual(self._trades(received)[0]["data"]["t"], 0)
+                    self.assertGreaterEqual(
+                        ubwa.get_stream_info(stream_id)["reconnects"], 1
+                    )
+                finally:
+                    ubwa.stop_manager()
+
+    def test_server_ping_is_answered(self):
+        print(f"test_server_ping_is_answered():")
+        for library in self.libraries:
+            with self.subTest(library=library):
+                self.server.pongs.pop("ping", None)
+                received = []
+                ubwa = self._manager(library, process_stream_data=received.append)
+                try:
+                    ubwa.create_stream(["trade"], ["ping"])
+                    self.assertTrue(
+                        self._wait_for(lambda: len(self._trades(received)) >= 1)
+                    )
+                    self.assertTrue(self.server.pongs.get("ping"))
+                finally:
+                    ubwa.stop_manager()
+
+    def test_unicode_payload(self):
+        print(f"test_unicode_payload():")
+        for library in self.libraries:
+            with self.subTest(library=library):
+                received = []
+                ubwa = self._manager(library, process_stream_data=received.append)
+                try:
+                    ubwa.create_stream(["trade"], ["unicode"])
+                    self.assertTrue(
+                        self._wait_for(lambda: len(self._trades(received)) >= 1)
+                    )
+                    self.assertEqual(self._trades(received)[0]["data"]["s"], "€ÜŸ–日本")
+                finally:
+                    ubwa.stop_manager()
+
+    def test_received_bytes_statistic(self):
+        print(f"test_received_bytes_statistic():")
+        for library in self.libraries:
+            with self.subTest(library=library):
+                received = []
+                ubwa = self._manager(
+                    library,
+                    output_default="raw_data",
+                    process_stream_data=received.append,
+                )
+                try:
+                    ubwa.create_stream(["trade"], ["bytes"])
+                    self.assertTrue(
+                        self._wait_for(
+                            lambda: sum(1 for m in received if '"data"' in m) >= 3
+                        )
+                    )
+                    time.sleep(0.2)
+                    expected = sum(len(m) for m in received)
+                    self.assertEqual(ubwa.get_total_received_bytes(), expected)
+                finally:
+                    ubwa.stop_manager()
+
+    def test_handshake_429_crashes_stream(self):
+        print(f"test_handshake_429_crashes_stream():")
+        for library in self.libraries:
+            with self.subTest(library=library):
+                # `create_stream()` blocks until the socket is ready unless
+                # `high_performance=True`; a rejected handshake never gets there.
+                ubwa = self._manager(library, scenario="http429", high_performance=True)
+                try:
+                    stream_id = ubwa.create_stream(["trade"], ["http429"])
+                    self.assertTrue(
+                        self._wait_for(
+                            lambda: ubwa.get_stream_info(stream_id)[
+                                "status"
+                            ].startswith("crashed"),
+                            15,
+                        )
+                    )
+                    self.assertEqual(ubwa.get_stream_info(stream_id)["reconnects"], 0)
+                finally:
+                    ubwa.stop_manager()
+
+    def test_handshake_404_keeps_restarting(self):
+        print(f"test_handshake_404_keeps_restarting():")
+        for library in self.libraries:
+            with self.subTest(library=library):
+                ubwa = self._manager(
+                    library,
+                    scenario="http404",
+                    restart_timeout=1,
+                    high_performance=True,
+                )
+                try:
+                    stream_id = ubwa.create_stream(["trade"], ["http404"])
+                    self.assertTrue(
+                        self._wait_for(
+                            lambda: self.server.connections.get("http404", 0) >= 3,
+                            20,
+                        )
+                    )
+                    self.assertEqual(
+                        ubwa.get_stream_info(stream_id)["status"], "restarting"
+                    )
+                finally:
+                    ubwa.stop_manager()
+
+    def test_websocket_api_request(self):
+        print(f"test_websocket_api_request():")
+        for library in self.libraries:
+            with self.subTest(library=library):
+                ubwa = self._manager(library)
+                try:
+                    stream_id = ubwa.create_stream(
+                        api=True, api_key="test-key", api_secret="test-secret"
+                    )
+                    self.assertTrue(
+                        self._wait_for(
+                            lambda: ubwa.is_socket_ready(stream_id=stream_id)
+                        )
+                    )
+                    response = ubwa.api.spot.get_server_time(
+                        stream_id=stream_id, return_response=True
+                    )
+                    self.assertEqual(response["result"]["serverTime"], 1234567890123)
+                finally:
+                    ubwa.stop_manager()
+
+    def test_keepalive_ping_timeout_reconnects(self):
+        # A server that never answers client pings: with `ping_interval=1`,
+        # `ping_timeout=1` both libraries must give up the connection and UBWA
+        # must reconnect. The server side needs picows (`websockets` always
+        # pongs), so this runs only when picows is installed.
+        print(f"test_keepalive_ping_timeout_reconnects():")
+        try:
+            import picows
+        except ImportError:
             self.skipTest("picows is not installed")
-        self._roundtrip("picows")
+
+        ready = threading.Event()
+        state = {"port": None}
+
+        class Listener(picows.WSListener):
+            def on_ws_connected(self, transport):
+                transport.send(
+                    picows.WSMsgType.TEXT,
+                    b'{"stream":"silent@trade","data":{"e":"trade","t":0}}',
+                )
+
+            def on_ws_frame(self, transport, frame):
+                if frame.msg_type == picows.WSMsgType.CLOSE:
+                    transport.send_close(
+                        frame.get_close_code(), frame.get_close_message()
+                    )
+                    transport.disconnect()
+                elif frame.msg_type == picows.WSMsgType.TEXT:
+                    request = orjson.loads(frame.get_payload_as_bytes())
+                    transport.send(
+                        picows.WSMsgType.TEXT,
+                        orjson.dumps({"result": None, "id": request["id"]}),
+                    )
+
+        async def serve():
+            server = await picows.ws_create_server(
+                lambda request: Listener(), "127.0.0.1", 0, enable_auto_pong=False
+            )
+            state["port"] = server.sockets[0].getsockname()[1]
+            ready.set()
+            async with server:
+                await server.serve_forever()
+
+        threading.Thread(target=lambda: asyncio.run(serve()), daemon=True).start()
+        self.assertTrue(ready.wait(10))
+
+        for library in self.libraries:
+            with self.subTest(library=library):
+                received = []
+                ubwa = self._manager(
+                    library,
+                    websocket_base_uri=f"ws://127.0.0.1:{state['port']}/",
+                    process_stream_data=received.append,
+                    restart_timeout=1,
+                )
+                try:
+                    stream_id = ubwa.create_stream(
+                        ["trade"], ["silent"], ping_interval=1, ping_timeout=1
+                    )
+                    self.assertTrue(
+                        self._wait_for(lambda: len(self._trades(received)) >= 1)
+                    )
+                    self.assertTrue(
+                        self._wait_for(
+                            lambda: ubwa.get_stream_info(stream_id)["reconnects"] >= 1,
+                            15,
+                        )
+                    )
+                finally:
+                    ubwa.stop_manager()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Extends the unit tests for the `websocket_library` switch from one roundtrip to a scenario suite, run for **both** libraries against a local stand-in server (no internet, deterministic). Found and fixed one real bug in the picows path on the way.

## Scenarios (`TestWebSocketLibrary`, each as a sub-test per library)

| Test | What it checks |
|---|---|
| `test_roundtrip` | idle-then-data (exercises the `wait_for(recv())` phase), 25 messages, subscribe → result |
| `test_reconnect_after_server_close` | server closes with 1001 → UBWA reconnects, resubscribes, `reconnects == 1`, signals `CONNECT/DISCONNECT/CONNECT` |
| `test_fragmented_message` | message split over three frames is reassembled |
| `test_large_message` | 450 KB (`!ticker@arr` size) arrives, no reconnect |
| `test_message_above_max_size_reconnects` | 1.5 MiB → 1009 close → reconnect, next message arrives |
| `test_server_ping_is_answered` | server ping gets a pong (Binance drops clients without one) |
| `test_unicode_payload` | non-ASCII JSON arrives intact |
| `test_received_bytes_statistic` | `get_total_received_bytes()` equals the sum of payload lengths (checks the `len()` change of #478) |
| `test_handshake_429_crashes_stream` | HTTP 429 on the handshake → stream `crashed`, no reconnect |
| `test_handshake_404_keeps_restarting` | HTTP 404 → stream keeps restarting, ≥3 attempts |
| `test_websocket_api_request` | `api=True` stream, `api.spot.get_server_time(return_response=True)` roundtrip |
| `test_keepalive_ping_timeout_reconnects` | picows server with auto-pong off, `ping_interval=1`/`ping_timeout=1` → both libraries drop the connection, UBWA reconnects |

Plus the three switch tests (default, unknown value, picows missing). ~3 min locally, picows scenarios skip without the package (CI installs it).

## Fixed

With `websocket_library="picows"` a rejected handshake killed the stream thread:

```
AttributeError: 'WSUpgradeResponse' object has no attribute 'status_code'
```

picows' `InvalidStatus` carries its raw `WSUpgradeResponse` (`status`, an `HTTPStatus`), `websockets`' carries a `Response` (`status_code`). The manager read `.status_code` inside the `except` clause, the `AttributeError` escaped, the thread died with no status update and no restart. New `websocket_library.get_http_status_code()` reads either attribute; `_run_socket()` uses it. Recorded in `context/websocket-library.md` (workaround, with a `Revisit when` for the day picows wraps the response).

## Notes

- The local server is `websockets`-based; the keepalive test additionally starts a raw picows server (`enable_auto_pong=False`) because `websockets` always pongs.
- `create_stream()` blocks until the socket is ready; the handshake-failure tests use `high_performance=True` so it returns immediately.
- CHANGELOG (Added/Fixed), AGENTS.md updated.
