### PR TITLE
chore: require picows>=2.2.0, drop the InvalidStatus.response shape workaround

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ and deliberately not part of `BINANCE_FUTURES_EXCHANGES`:
 Managed in `requirements.txt`, `setup.py`, and `pyproject.toml` — **all three must be kept in sync manually** (IDE find/replace):
 
 - `websocket-client`, `websockets>=14.0` — WebSocket connections
-- `picows>=2.1.0` — **optional** (extra `picows`), alternative WebSocket library via its
+- `picows>=2.2.0` — **optional** (extra `picows`), alternative WebSocket library via its
   `websockets`-compatible API; selected with `BinanceWebSocketApiManager(websocket_library="picows")`,
   see [`context/websocket-library.md`](context/websocket-library.md). Benchmark:
   `dev/test_websocket_library_benchmark.py`, profile of the stream thread:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   restarting), a WebSocket API request/response roundtrip and the
   keepalive ping timeout (server that never pongs -> reconnect).
 ### Changed
+- The `picows` extra requires `picows>=2.2.0` (was 2.1.0): 2.2.0 fixes
+  [tarasko/picows#108](https://github.com/tarasko/picows/issues/108)
+  (`InvalidStatus.response` is now the `websockets`-shaped `Response` with
+  `status_code`), so `websocket_library.get_http_status_code()` reads
+  `status_code` only again. Scenario suite and a 24 h soak against binance.com
+  (both libraries in parallel, 0 errors, picows ~26 % less CPU) documented in
+  [`context/websocket-library.md`](context/websocket-library.md).
 - Stream loop hot path slimmed down (per received message): removed 18
   `logger.debug()` f-string calls that were evaluated with debug logging off,
   5 of 7 lock cycles (per-stream counters have a single writer, the stream's

--- a/README.md
+++ b/README.md
@@ -531,8 +531,9 @@ Selecting `"picows"` without the package installed raises an `ImportError`, an u
 there is no silent fallback. SOCKS5 proxies work with both libraries. The [conda-forge](https://anaconda.org/conda-forge/picows)
 package is `picows`.
 
-`picows` support is new and opt-in: `websockets` stays the default until picows has settled (see
-[tarasko/picows#108](https://github.com/tarasko/picows/issues/108)) and enough real-world reports are in. Questions,
+`picows` support is new and opt-in: `websockets` stays the default until picows has proven itself in real-world use
+and enough reports are in (the first upstream finding, [tarasko/picows#108](https://github.com/tarasko/picows/issues/108),
+is fixed in picows 2.2.0, the minimum version the extra requires). Questions,
 experiences and your own benchmark numbers:
 [issue #477 - WebSocket library: websockets vs. picows](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/477).
 

--- a/context/websocket-library.md
+++ b/context/websocket-library.md
@@ -22,11 +22,16 @@ its own thread/event loop. Reusing that path means zero duplicated stream
 logic and no second code path to keep in sync. Chosen as the first step
 explicitly; a native integration was to be *assessed*, not built (next entry).
 
-**Version floor `picows>=2.1.0`** rather than 2.0.0 (where `picows.websockets`
-first appeared): 2.1.0 completed the compat surface (`open`/`closed`
-attributes, `protocol.State`, `WebSocketClientProtocol` alias). UBWA does not
-use those today; the floor buys the complete API in case it does. Evidence
-for this sub-choice: inferred from the picows release notes.
+**Version floor `picows>=2.2.0`**: 2.2.0 is the first release whose
+`InvalidStatus.response` is the `websockets`-shaped `Response` with
+`status_code` ([tarasko/picows#108](https://github.com/tarasko/picows/issues/108),
+fixed 2026-09-11, verified against 2.2.0 by the scenario suite). Before that
+the floor was 2.1.0 rather than 2.0.0 (where `picows.websockets` first
+appeared) because 2.1.0 completed the compat surface (`open`/`closed`
+attributes, `protocol.State`, `WebSocketClientProtocol` alias) - UBWA does
+not use those today, the floor bought the complete API in case it does.
+Raising to 2.2.0 keeps that and removes the need to handle two response
+shapes.
 
 ## Native picows core API (`ws_connect()` + `WSListener`) - measured, not built
 
@@ -75,7 +80,7 @@ per-message work - see `stream-loop.md`.
 **Status:** active
 **Evidence:** confirmed
 **Source:** maintainer decisions 2026-09-10 (opt-in after the scenario suite of PR #479 and the upstream report [tarasko/picows#108](https://github.com/tarasko/picows/issues/108); soak requested the same day, release only after it)
-**Revisit when:** picows has fixed and released #108 and the first opt-in users have reported back in #477 - then decide about promoting picows beyond opt-in (the soak gate below is passed)
+**Revisit when:** the first opt-in users have reported back in #477 - then decide about promoting picows beyond opt-in (the soak gate below is passed, #108 is fixed in picows 2.2.0 and the floor raised)
 
 picows support ships as an optional extra (`pip install
 unicorn-binance-websocket-api[picows]`), selected explicitly per manager,
@@ -89,7 +94,7 @@ minute) before the release that ships picows support.
 
 **Reason:** the remaining risk sits with users who opt in knowingly, the
 default path is untouched, and picows' compat layer itself is still moving
-(#108). Real usage is expected to surface the next issues; the community
+(#108, fixed upstream within a day). Real usage is expected to surface the next issues; the community
 channel is [issue #477](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/477). The
 soak is the minimum evidence for "runs for a day" before telling anyone to
 opt in.
@@ -127,13 +132,18 @@ restart logic therefore catches tuples
 (`CONNECTION_CLOSED_EXCEPTIONS`, ...) built in `websocket_library.py`; the
 picows classes are appended only when the package is importable.
 
-## `InvalidStatus.response` differs between the families
+## `InvalidStatus.response` differed between the families (picows < 2.2.0)
 
 **Type:** workaround
-**Status:** active
+**Status:** superseded
 **Evidence:** confirmed
-**Source:** picows 2.1.3 `picows/websockets/asyncio/client.py` (`raise InvalidStatus(exc.response)` with the raw `WSUpgradeResponse`); found by `TestWebSocketLibrary.test_handshake_429_crashes_stream`
-**Revisit when:** [tarasko/picows#108](https://github.com/tarasko/picows/issues/108) is fixed and released (picows wraps the response in its compat `Response`, which has `status_code`) - then the helper can go back to reading `status_code` only
+**Source:** picows 2.1.3 `picows/websockets/asyncio/client.py` (`raise InvalidStatus(exc.response)` with the raw `WSUpgradeResponse`); found by `TestWebSocketLibrary.test_handshake_429_crashes_stream`; superseded by picows 2.2.0 ([tarasko/picows#108](https://github.com/tarasko/picows/issues/108) fixed 2026-09-11) and the version floor `picows>=2.2.0`
+
+Superseded: since the extra requires picows 2.2.0, both families attach a
+`Response` with `status_code` and `get_http_status_code()` reads that
+attribute only. The helper stays as the single place the manager gets the
+code from (returns `None` instead of raising when the shape is unexpected),
+the `status` fallback is gone. History below.
 
 The manager decides on a rejected handshake by HTTP status (429 -> crash the
 stream, anything else -> restart). `websockets` puts a `Response` with

--- a/context/websocket-library.md
+++ b/context/websocket-library.md
@@ -75,7 +75,7 @@ per-message work - see `stream-loop.md`.
 **Status:** active
 **Evidence:** confirmed
 **Source:** maintainer decisions 2026-09-10 (opt-in after the scenario suite of PR #479 and the upstream report [tarasko/picows#108](https://github.com/tarasko/picows/issues/108); soak requested the same day, release only after it)
-**Revisit when:** the soak result is in (see below) and picows has fixed and released #108 - then decide about promoting picows beyond opt-in
+**Revisit when:** picows has fixed and released #108 and the first opt-in users have reported back in #477 - then decide about promoting picows beyond opt-in (the soak gate below is passed)
 
 picows support ships as an optional extra (`pip install
 unicorn-binance-websocket-api[picows]`), selected explicitly per manager,
@@ -97,8 +97,22 @@ opt in.
 **Not covered by the soak:** userData streams and the WebSocket API against
 real credentials (no testnet key on the soak host), macOS/Windows.
 
-**Soak result:** pending (started 2026-09-10 16:19 CEST, results under the
-soak output directory, to be summarized here).
+**Soak result (measured 2026-09-10 22:41 → 2026-09-11 22:41 CEST, 8 cores /
+12 GB VM, Python 3.13.5, picows 2.1.3, websockets 16.0):** clean for both
+libraries, no picows-specific finding. picows 138.8 M messages (avg 1.6 k/s,
+peak 8.3 k/s, 49.9 GB), RSS 62 → 126 MB, CPU avg 9.5 %; websockets 137.9 M
+messages, RSS 63 → 149 MB, CPU avg 12.8 %. Zero errors, zero stalls (max
+5 s without data), zero unrepairable streams, zero ERROR/WARNING lines.
+Reconnects: 2 / 80 / 2 (picows) vs 2 / 88 / 2 (websockets) on the
+arr / markets / depth streams, every one back in 5-6 s with subscriptions
+re-queued. 90 % of them were `keepalive ping timeout` on the 250-subscription
+markets connection during a 14:29-18:21 CEST window in which the rate rose
+to 3-8 k msgs/s; both libraries dropped in the same seconds, so the cause is
+Binance/network under load against UBWA's `ping_interval=5` /
+`ping_timeout=10` defaults, not the library. RSS stepped up at rate peaks and
+was flat for the final 4.5 h despite further reconnects - buffer high-water
+mark, not a per-reconnect leak (pattern evidence, no tracemalloc). Full
+tables in the soak output directory (`REPORT.md`).
 
 ## Why the picows exception classes are caught separately
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ unicorn-fy = ">=0.17.2"
 unicorn-binance-rest-api = ">=2.12.0"
 websocket-client = "*"
 websockets = ">=14.0"
-picows = { version = ">=2.1.0", optional = true }
+picows = { version = ">=2.2.0", optional = true }
 
 [tool.poetry.extras]
 picows = ["picows"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ websocket-client
 websockets>=14.0
 # Optional (extra `picows`): alternative WebSocket client library, select with
 # BinanceWebSocketApiManager(websocket_library="picows")
-# picows>=2.1.0
+# picows>=2.2.0

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
     ],
     extras_require={
         # Optional alternative WebSocket client library, see README "WebSocket library"
-        "picows": ["picows>=2.1.0"],
+        "picows": ["picows>=2.2.0"],
     },
     keywords="binance, asyncio, async, asynchronous, concurrent, websocket-api, webstream-api, "
     "binance-websocket, binance-webstream, webstream, websocket, api, binance-dex, "

--- a/unicorn_binance_websocket_api/websocket_library.py
+++ b/unicorn_binance_websocket_api/websocket_library.py
@@ -96,18 +96,16 @@ NEGOTIATION_ERROR_EXCEPTIONS = _exception_tuple("NegotiationError")
 
 def get_http_status_code(error: BaseException) -> Optional[int]:
     """
-    HTTP status of a rejected handshake (`InvalidStatus` of either family).
+    HTTP status of a rejected handshake (`InvalidStatus` of either family),
+    `None` when the exception carries no usable response.
 
-    `websockets` attaches a `Response` with `status_code`; `picows.websockets`
-    (2.1.x) attaches picows' raw `WSUpgradeResponse`, which only has
-    `status` (an `HTTPStatus`). Reading `.status_code` blindly killed the
-    stream thread with an `AttributeError` on picows - a silent death instead
-    of the crash/restart decision the manager makes from the code.
+    Both families attach a `Response` with `status_code` (picows since 2.2.0,
+    the version floor of the extra; 2.1.x attached the raw `WSUpgradeResponse`
+    without it, see tarasko/picows#108). The manager decides crash vs.
+    restart from this code and must never die on the shape of the exception.
     """
     response = getattr(error, "response", None)
     code = getattr(response, "status_code", None)
-    if code is None:
-        code = getattr(response, "status", None)
     if code is None:
         return None
     try:


### PR DESCRIPTION
Stacked on #480 (merge that first; this PR then shows only its own commit).

picows 2.2.0 (released 2026-09-11) closes [tarasko/picows#108](https://github.com/tarasko/picows/issues/108): `InvalidStatus.response` is now the `websockets`-shaped `Response` with `status_code`. Verified locally against 2.2.0 (a rejected handshake now yields `picows.websockets.compat.Response`, `status_code=404`).

Changes:
- Version floor of the `picows` extra 2.1.0 → 2.2.0 in `setup.py`, `pyproject.toml`, `requirements.txt`, `AGENTS.md`.
- `websocket_library.get_http_status_code()` reads `status_code` only again; the `status` fallback is gone. The helper stays as the single accessor (returns `None` instead of raising on an unexpected shape).
- `context/websocket-library.md`: floor entry rewritten for 2.2.0, workaround entry marked superseded, revisit condition of the opt-in decision now depends only on #477 feedback.
- README opt-in paragraph: still "new and opt-in", the #108 reference now says it is fixed in 2.2.0 (the required minimum).
- CHANGELOG entry under Changed.

Tests: `TestWebSocketLibrary` (15 tests, 24 subtests, both libraries against the local stand-in server) green on picows 2.2.0 before and after the change. `ktw-lint` clean, black clean.

Not touched: `dev/sphinx/source/readme.md` (synced at release time), benchmark tables (measured on 2.1.3, still valid as measurements).